### PR TITLE
Fix ESLint command not linting anything

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,13 +1,13 @@
 {
   "private": true,
   "scripts": {
-    "postinstall": "yarn lint:fix app/index.js",
     "build": "tsc -b packages/tsconfig.json",
     "watch": "tsc -b -w packages/tsconfig.json",
     "test": "cd packages; npx jest --projects anki-import api-client backend core firebase-support web-component note-sync --runInBand",
     "test:watch": "yarn run test --watch",
-    "lint": "cd packages; eslint",
-    "lint:fix": "cd packages; eslint --fix"
+    "lint": "cd packages; eslint .",
+    "lint:fix": "cd packages; eslint --fix .",
+    "postinstall": "cd packages; eslint --fix app/index.js"
   },
   "devDependencies": {
     "@typescript-eslint/eslint-plugin": "^4.6.0",


### PR DESCRIPTION
Sorry for the flurry of PR's today... 

In https://github.com/andymatuschak/orbit/pull/198 I made the mistake of not explicitly setting the path for ESLint. I foolishly assumed that forgoing the path would mean ESLint would lint all the directories, but instead it lints nothing. It finishing in 0.5s should have been a clear giveaway 🤦‍♂️.

Anyways, I went ahead and reversed my change where I removed the path from the command. I also changed the `postinstall` script to call eslint directly instead of using `yarn lint` to ensure that we are only running lint fix on that single file.