### PR TITLE
App fails to load when trackers are blocked

### DIFF
--- a/packages/app/src/errorReporting/reporter.ts
+++ b/packages/app/src/errorReporting/reporter.ts
@@ -18,14 +18,17 @@ export function initializeReporter() {
   if (!enabled) {
     console.log("[sentry] Disabling Sentry in development");
   }
-
-  Sentry.onLoad(() => {
-    Sentry.init({
-      enabled,
-      release: `${serviceConfig.sentryProject}@${GitInfo().commit.hash}`,
+  try {
+    Sentry.onLoad(() => {
+      Sentry.init({
+        enabled,
+        release: `${serviceConfig.sentryProject}@${GitInfo().commit.hash}`,
+      });
+      Sentry.setTags({
+        platform: "web",
+      });
     });
-    Sentry.setTags({
-      platform: "web",
-    });
-  });
+  } catch (e) {
+    console.error('[sentry] Failed to load Sentry');
+  }
 }


### PR DESCRIPTION
Hey @andymatuschak , I was looking forward to trying out Orbit, but can't even access the site at all on Firefox with uBlock origin, since the Sentry script gets blocked. then `initializeReporter` throws, preventing `<App/>` from displaying at all because there is no Sentry global. 

![Screen Shot 2021-05-05 at 9 43 14 AM](https://user-images.githubusercontent.com/11509865/117177861-53ea0280-ad86-11eb-8f47-69904e39fb30.png)
