### PR TITLE
Upgrade Typescript to 4.2.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "lerna": "^3.20.2",
     "prettier": "^2.0.2",
     "ts-node": "^9.0.0",
-    "typescript": "^4.0.5"
+    "typescript": "^4.2.4"
   },
   "workspaces": [
     "packages/*",

--- a/packages/anki-import/package.json
+++ b/packages/anki-import/package.json
@@ -37,7 +37,7 @@
     "jest-environment-uint8array": "^1.0.0",
     "sqlite": "^3.0.6",
     "ts-jest": "^26.4.4",
-    "typescript": "^4.0.5",
+    "typescript": "^4.2.4",
     "unist-util-map": "^2.0.1"
   }
 }

--- a/packages/anki-import/src/importPlan.ts
+++ b/packages/anki-import/src/importPlan.ts
@@ -314,7 +314,9 @@ export async function createImportPlan(
       promptActionLog.taskID,
       applyActionLogToPromptState({
         promptActionLog,
-        actionLogID: await getIDForActionLog(promptActionLog),
+        actionLogID: await getIDForActionLog(
+          getActionLogFromPromptActionLog(promptActionLog),
+        ),
         schedule: "default",
         basePromptState: null,
       }) as PromptState,
@@ -336,11 +338,13 @@ export async function createImportPlan(
     }
 
     const promptActionLog = await createPlanForLog(ankiLog, cardLastActionLog);
-    plan.logs.push(promptActionLog);
+    plan.logs.push(getActionLogFromPromptActionLog(promptActionLog));
 
     const newPromptState = applyActionLogToPromptState({
       promptActionLog,
-      actionLogID: await getIDForActionLog(promptActionLog),
+      actionLogID: await getIDForActionLog(
+        getActionLogFromPromptActionLog(promptActionLog),
+      ),
       schedule: "default",
       basePromptState: taskIDsToPromptStates.get(promptActionLog.taskID)!,
     }) as PromptState;

--- a/packages/api-client/package.json
+++ b/packages/api-client/package.json
@@ -16,7 +16,7 @@
     "babel-jest": "^26.6.3",
     "jest": "~26.6.3",
     "@withorbit/sample-data": "0.0.1",
-    "typescript": "^4.0.5"
+    "typescript": "^4.2.4"
   },
   "dependencies": {
     "@withorbit/api": "0.0.1",

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -10,6 +10,6 @@
   },
   "dependencies": {},
   "devDependencies": {
-    "typescript": "^4.0.5"
+    "typescript": "^4.2.4"
   }
 }

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -113,7 +113,7 @@
     "react-git-info": "^2.0.0",
     "react-test-renderer": "~17.0.1",
     "ts-node": "^9.0.0",
-    "typescript": "~4.0.0",
+    "typescript": "^4.2.4",
     "webpack-bundle-analyzer": "^3.8.0"
   },
   "jest": {

--- a/packages/app/src/embedded/markingActions.ts
+++ b/packages/app/src/embedded/markingActions.ts
@@ -3,6 +3,7 @@ import {
   applicationPromptType,
   ClozePromptParameters,
   clozePromptType,
+  getActionLogFromPromptActionLog,
   getClozeDeletionCount,
   getIDForActionLogSync,
   getIDForPromptTask,
@@ -156,7 +157,7 @@ export function getActionsRecordForMarking({
   };
   const repetitionLogEntry = {
     log: repetitionLog,
-    id: getIDForActionLogSync(repetitionLog),
+    id: getIDForActionLogSync(getActionLogFromPromptActionLog(repetitionLog)),
   };
 
   return {

--- a/packages/app/src/model/databaseManager.ts
+++ b/packages/app/src/model/databaseManager.ts
@@ -1,5 +1,6 @@
 import OrbitAPIClient from "@withorbit/api-client";
 import {
+  ActionLog,
   ActionLogID,
   applyActionLogToPromptState,
   getActionLogFromPromptActionLog,
@@ -94,7 +95,7 @@ export default class DatabaseManager {
     const promptLogEntries = await Promise.all(
       [...entries].map(async (log) => ({
         log,
-        id: await getIDForActionLog(log),
+        id: await getIDForActionLog(getActionLogFromPromptActionLog(log)),
       })),
     );
 
@@ -180,7 +181,10 @@ export default class DatabaseManager {
       }
     }
 
-    await this.actionLogStore.saveActionLogs(entries);
+    // NOTE: As of Typescript 4.2.4 PromptActionLog is not equivalent ActionLog. Looks to be compiler limitation
+    await this.actionLogStore.saveActionLogs(
+      entries as { log: ActionLog; id: ActionLogID }[],
+    );
 
     await this.promptStateStore.savePromptStates(
       updates.map(({ newPromptState, taskID }) => ({

--- a/packages/app/src/model/databaseManager.ts
+++ b/packages/app/src/model/databaseManager.ts
@@ -183,7 +183,10 @@ export default class DatabaseManager {
 
     // NOTE: As of Typescript 4.2.4 PromptActionLog is not equivalent ActionLog. Looks to be compiler limitation
     await this.actionLogStore.saveActionLogs(
-      entries as { log: ActionLog; id: ActionLogID }[],
+      entries.map(({ id, log }) => ({
+        id,
+        log: getActionLogFromPromptActionLog(log),
+      })),
     );
 
     await this.promptStateStore.savePromptStates(

--- a/packages/app/src/model/databaseManager.ts
+++ b/packages/app/src/model/databaseManager.ts
@@ -1,6 +1,5 @@
 import OrbitAPIClient from "@withorbit/api-client";
 import {
-  ActionLog,
   ActionLogID,
   applyActionLogToPromptState,
   getActionLogFromPromptActionLog,

--- a/packages/app/src/reviewSession/ReviewSession.tsx
+++ b/packages/app/src/reviewSession/ReviewSession.tsx
@@ -4,6 +4,7 @@ import {
   getIDForActionLogSync,
   getIDForPromptSync,
   getIDForPromptTask,
+  getActionLogFromPromptActionLog,
   getNextTaskParameters,
   PromptActionLog,
   PromptProvenanceType,
@@ -107,7 +108,14 @@ function persistMarking({
       console.error("Couldn't commit", reviewItem.prompt, error);
     });
 
-  return [{ log: promptActionLog, id: getIDForActionLogSync(promptActionLog) }];
+  return [
+    {
+      log: promptActionLog,
+      id: getIDForActionLogSync(
+        getActionLogFromPromptActionLog(promptActionLog),
+      ),
+    },
+  ];
 }
 
 function useReviewItemQueue(

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -74,7 +74,7 @@
     "rollup-plugin-extensions": "^0.1.0",
     "ts-loader": "^8.0.11",
     "ts-node": "^9.0.0",
-    "typescript": "^4.0.5"
+    "typescript": "^4.2.4"
   },
   "workspaces": {
     "nohoist": [

--- a/packages/backend/src/applyPromptActionLogToPromptStateCache.ts
+++ b/packages/backend/src/applyPromptActionLogToPromptStateCache.ts
@@ -1,6 +1,7 @@
 import {
   ActionLogID,
   applyActionLogToPromptState,
+  getActionLogFromPromptActionLog,
   getIDForActionLog,
   getPromptActionLogFromActionLog,
   mergeActionLogs,
@@ -37,7 +38,9 @@ export default async function applyActionLogDocumentToPromptStateCache({
   ) {
     const newPromptState = applyActionLogToPromptState({
       basePromptState: basePromptStateCache,
-      actionLogID: await getIDForActionLog(promptActionLog),
+      actionLogID: await getIDForActionLog(
+        getActionLogFromPromptActionLog(promptActionLog),
+      ),
       promptActionLog,
       schedule: "default",
     });

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -27,7 +27,7 @@
   "devDependencies": {
     "@types/yargs": "^15.0.9",
     "ts-node": "^9.0.0",
-    "typescript": "^4.0.5"
+    "typescript": "^4.2.4"
   },
   "workspaces": {
     "nohoist": [

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -17,7 +17,7 @@
     "babel-jest": "^26.6.3",
     "jest": "~26.6.3",
     "jest-environment-uint8array": "^1.0.0",
-    "typescript": "^4.0.5"
+    "typescript": "^4.2.4"
   },
   "dependencies": {
     "@aws-crypto/sha256-js": "^1.0.0",

--- a/packages/core/src/promptState/applyActionLogToPromptState.test.ts
+++ b/packages/core/src/promptState/applyActionLogToPromptState.test.ts
@@ -200,7 +200,9 @@ describe("repetition", () => {
         ...testRepetitionLog,
         outcome: PromptRepetitionOutcome.Forgotten,
       };
-      const logID = await getIDForActionLog(log);
+      const logID = await getIDForActionLog(
+        getActionLogFromPromptActionLog(log),
+      );
 
       const promptState = applyActionLogToPromptState({
         promptActionLog: log,
@@ -245,7 +247,9 @@ describe("repetition", () => {
       };
       const nextPromptState = applyActionLogToPromptState({
         promptActionLog: log,
-        actionLogID: await getIDForActionLog(log),
+        actionLogID: await getIDForActionLog(
+          getActionLogFromPromptActionLog(log),
+        ),
         basePromptState,
         schedule: testSchedule,
       }) as PromptState;
@@ -273,7 +277,9 @@ describe("repetition", () => {
       };
       const nextPromptState = applyActionLogToPromptState({
         promptActionLog: log,
-        actionLogID: await getIDForActionLog(log),
+        actionLogID: await getIDForActionLog(
+          getActionLogFromPromptActionLog(log),
+        ),
         basePromptState,
         schedule: testSchedule,
       }) as PromptState;
@@ -294,7 +300,7 @@ describe("repetition", () => {
         promptParameters: null,
       }),
     };
-    const logID = await getIDForActionLog(log);
+    const logID = await getIDForActionLog(getActionLogFromPromptActionLog(log));
     expect(
       (applyActionLogToPromptState({
         promptActionLog: log,

--- a/packages/core/src/types/promptActionLog.test.ts
+++ b/packages/core/src/types/promptActionLog.test.ts
@@ -40,8 +40,9 @@ describe("repetition", () => {
     context: null,
   };
 
-  const p = promptActionLog.taskParameters;
-  p.variantIndex;
+  // NOTE: As of Typescript 4.2.4 PromptActionLog is not equivalent ActionLog. Looks to be compiler limitation
+  const p = promptActionLog.taskParameters as { variantIndex: number };
+  expect(p.variantIndex).toBeDefined();
 
   const actionLog = getActionLogFromPromptActionLog(promptActionLog);
   test("round trip", () => {

--- a/packages/core/src/types/promptActionLog.ts
+++ b/packages/core/src/types/promptActionLog.ts
@@ -62,7 +62,8 @@ export type PromptActionLog<PT extends PromptTask = PromptTask> =
 export function getActionLogFromPromptActionLog(
   promptActionLog: PromptActionLog,
 ): ActionLog {
-  return promptActionLog;
+  // NOTE: As of Typescript 4.2.4 PromptActionLog is not equivalent ActionLog. Looks to be compiler limitation
+  return promptActionLog as ActionLog;
 }
 
 export function getPromptActionLogFromActionLog(

--- a/packages/embedded-support/package.json
+++ b/packages/embedded-support/package.json
@@ -12,6 +12,6 @@
     "@withorbit/core": "0.0.1"
   },
   "devDependencies": {
-    "typescript": "^4.0.5"
+    "typescript": "^4.2.4"
   }
 }

--- a/packages/firebase-support/package.json
+++ b/packages/firebase-support/package.json
@@ -29,6 +29,6 @@
     "@types/sha.js": "^2.4.0",
     "babel-jest": "^26.6.3",
     "jest": "~26.6.3",
-    "typescript": "^4.0.5"
+    "typescript": "^4.2.4"
   }
 }

--- a/packages/note-sync/package.json
+++ b/packages/note-sync/package.json
@@ -47,6 +47,6 @@
     "ts-loader": "^8.0.11",
     "ts-node": "^9.0.0",
     "tsconfig-paths": "^3.9.0",
-    "typescript": "^4.0.5"
+    "typescript": "^4.2.4"
   }
 }

--- a/packages/note-sync/vendor/computer-supported-thinking/spaced-everything-cli/package.json
+++ b/packages/note-sync/vendor/computer-supported-thinking/spaced-everything-cli/package.json
@@ -18,7 +18,7 @@
     "@types/node": "~10",
     "globby": "^10.0.2",
     "ts-node": "~8",
-    "typescript": "beta"
+    "typescript": "^4.2.4"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/packages/note-sync/vendor/computer-supported-thinking/spaced-everything/package.json
+++ b/packages/note-sync/vendor/computer-supported-thinking/spaced-everything/package.json
@@ -22,7 +22,7 @@
     "prettier": "^2.0.2",
     "ts-jest": "^25.2.1",
     "ts-node": "^8.8.1",
-    "typescript": "^3.8.3"
+    "typescript": "^4.2.4"
   },
   "dependencies": {
     "array-flat-polyfill": "^1.0.1",

--- a/packages/note-sync/vendor/computer-supported-thinking/spaced-everything/src/taskCache/JSONCache.test.ts
+++ b/packages/note-sync/vendor/computer-supported-thinking/spaced-everything/src/taskCache/JSONCache.test.ts
@@ -120,7 +120,7 @@ describe("mock cache", () => {
         },
       },
       value: {},
-    });
+    }) as TaskCache<TestTask, TestTaskCollection>;
 
     await testCache.performOperations(async (session) => {
       await session.writeChanges([
@@ -152,7 +152,7 @@ describe("mock cache", () => {
         },
       },
       value: {},
-    });
+    }) as TaskCache<TestTask, TestTaskCollection>;
 
     await testCache.performOperations(async (session) => {
       await session.writeChanges([

--- a/packages/note-sync/vendor/computer-supported-thinking/vendor/incremental-thinking/package.json
+++ b/packages/note-sync/vendor/computer-supported-thinking/vendor/incremental-thinking/package.json
@@ -28,7 +28,7 @@
     "prettier": "^1.19.1",
     "ts-jest": "^25.2.1",
     "ts-node": "^8.8.1",
-    "typescript": "^3.8.3"
+    "typescript": "^4.2.4"
   },
   "scripts": {
     "build": "tsc -b",

--- a/packages/note-sync/vendor/computer-supported-thinking/yarn.lock
+++ b/packages/note-sync/vendor/computer-supported-thinking/yarn.lock
@@ -5063,15 +5063,10 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
-typescript@^3.8.3:
-  version "3.8.3"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.8.3.tgz#409eb8544ea0335711205869ec458ab109ee1061"
-  integrity sha512-MYlEfn5VrLNsgudQTVJeNaQFUAI7DkhnOjdpAp4T+ku1TfQClewlbSuTVHiA+8skNBgaf02TL/kLOvig4y3G8w==
-
-typescript@beta:
-  version "3.8.0-beta"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.8.0-beta.tgz#acdcaf9f24c7e20b1ff0a6329d1e8d63691e2e13"
-  integrity sha512-mQEmQUJg0CQBhf/GSVnGscKv/jrKsrLxE01AhdjYmBNoXX2Iah3i38ufxXByXacK6Fc5Nr9oMz7MjpjgddiknA==
+typescript@^4.2.4:
+  version "4.2.4"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.2.4.tgz#8610b59747de028fda898a8aef0e103f156d0961"
+  integrity sha512-V+evlYHZnQkaz8TRBuxTA92yZBPotr5H+WhQ7bD3hZUndx5tGOa1fuCgeSjxAzM1RiN5IzvadIXTVefuuwZCRg==
 
 tz-lookup@^6.1.24:
   version "6.1.25"

--- a/packages/sample-data/package.json
+++ b/packages/sample-data/package.json
@@ -11,7 +11,7 @@
     "@withorbit/core": "0.0.1"
   },
   "devDependencies": {
-    "typescript": "^4.0.5"
+    "typescript": "^4.2.4"
   },
   "scripts": {
     "build": "tsc -b"

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -43,7 +43,7 @@
     "seedrandom": "^3.0.5",
     "svgs": "^4.1.1",
     "ts-jest": "^26.4.4",
-    "typescript": "^4.0.5"
+    "typescript": "^4.2.4"
   },
   "peerDependencies": {
     "@types/react": "^16.9.23",

--- a/packages/ui/src/components/Card.tsx
+++ b/packages/ui/src/components/Card.tsx
@@ -1,6 +1,8 @@
 import {
+  ApplicationPrompt,
   ApplicationPromptTask,
   applicationPromptType,
+  ClozePrompt,
   ClozePromptTask,
   clozePromptType,
   createClozeMarkupRegexp,
@@ -41,9 +43,14 @@ function getQAPromptContents<PT extends QAPromptTask | ApplicationPromptTask>(
       const applicationReviewItem = reviewItem as ReviewAreaItem<
         ApplicationPromptTask
       >;
-      return applicationReviewItem.prompt.variants[
-        applicationReviewItem.taskParameters.variantIndex
-      ];
+      const taskParameters = applicationReviewItem.taskParameters as {
+        variantIndex: number;
+      };
+      const applicationPrompt = applicationReviewItem.prompt as ApplicationPrompt;
+
+      return applicationPrompt.variants[taskParameters.variantIndex];
+    case clozePromptType:
+      throw new Error("cloze prompt is not a QA prompt");
   }
 }
 
@@ -352,9 +359,10 @@ function ClozePromptRenderer({
   reviewItem,
 }: ClozePromptRendererProps) {
   const {
-    prompt: { body },
+    prompt,
     promptParameters: { clozeIndex },
   } = reviewItem;
+  const { body } = prompt as ClozePrompt;
   const front = {
     ...body,
     contents: formatClozePromptContents(body.contents, false, clozeIndex),

--- a/packages/ui/src/components/ReviewArea.stories.tsx
+++ b/packages/ui/src/components/ReviewArea.stories.tsx
@@ -1,6 +1,7 @@
 import { boolean, number, text, withKnobs } from "@storybook/addon-knobs";
 import {
   applyActionLogToPromptState,
+  getActionLogFromPromptActionLog,
   getIDForActionLog,
   getIDForPromptTask,
   PromptID,
@@ -113,7 +114,9 @@ function ReviewAreaTemplate({
               taskParameters: null,
               timestampMillis: Date.now(),
             };
-            const actionLogID = await getIDForActionLog(log);
+            const actionLogID = await getIDForActionLog(
+              getActionLogFromPromptActionLog(log),
+            );
             setLocalPromptStates((states) => {
               return [
                 ...states,

--- a/packages/web-component/package.json
+++ b/packages/web-component/package.json
@@ -19,7 +19,7 @@
     "firebase-tools": "^9.6.1",
     "jest": "^26.6.3",
     "ts-loader": "^8.0.11",
-    "typescript": "^4.0.5",
+    "typescript": "^4.2.4",
     "webpack": "^5.4.0",
     "webpack-cli": "^4.2.0"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -27208,20 +27208,10 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
-typescript@^3.8.3:
-  version "3.9.9"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.9.9.tgz#e69905c54bc0681d0518bd4d587cc6f2d0b1a674"
-  integrity sha512-kdMjTiekY+z/ubJCATUPlRDl39vXYiMV9iyeMuEuXZh2we6zz80uovNN2WlAxmmdE/Z/YQe+EbOEXB5RHEED3w==
-
-typescript@^4.0.5:
-  version "4.0.5"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.0.5.tgz#ae9dddfd1069f1cb5beb3ef3b2170dd7c1332389"
-  integrity sha512-ywmr/VrTVCmNTJ6iV2LwIrfG1P+lv6luD8sUJs+2eI9NLGigaN+nUQc13iHqisq7bra9lnmUSYqbJvegraBOPQ==
-
-typescript@~4.0.0:
-  version "4.0.7"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.0.7.tgz#7168032c43d2a2671c95c07812f69523c79590af"
-  integrity sha512-yi7M4y74SWvYbnazbn8/bmJmX4Zlej39ZOqwG/8dut/MYoSQ119GY9ZFbbGsD4PFZYWxqik/XsP3vk3+W5H3og==
+typescript@^4.2.4:
+  version "4.2.4"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.2.4.tgz#8610b59747de028fda898a8aef0e103f156d0961"
+  integrity sha512-V+evlYHZnQkaz8TRBuxTA92yZBPotr5H+WhQ7bD3hZUndx5tGOa1fuCgeSjxAzM1RiN5IzvadIXTVefuuwZCRg==
 
 typical@^5.0.0, typical@^5.2.0:
   version "5.2.0"


### PR DESCRIPTION
To use `ajv` for the upcoming https://github.com/andymatuschak/orbit/issues/184 PR, the latest version of typescript is required. I also went ahead and standardized the typescript version throughout all the packages.

In the process of this upgrade it looks like Typescript is having trouble coercing `ActionLog` and `PromptActionLog` as equivalent. Specifically, it looks like the [taskParameters of RepetitionActionLog](https://github.com/andymatuschak/orbit/blob/master/packages/core/src/types/actionLog.ts#L21) and [taskParameters of PromptRepetitionActionLog](https://github.com/andymatuschak/orbit/blob/master/packages/core/src/types/promptActionLog.ts#L37) is the property blocking this equivalency despite them being equivalent in theory. To circumvent this problem a force cast between the two types were introduced in the code.

**How I tested this?**
- `yarn build` and `yarn test` at the root
- `yarn run dev` for the backend to make sure the backend still compiled correctly
- `yarn sync` for the `note-sync` package to make sure its CLI was not affected.
- `yarn storybook` for the UI