### PR TITLE
Add validation to the /actionLogs endpoint

### DIFF
--- a/packages/api-client/src/orbitAPIClient.ts
+++ b/packages/api-client/src/orbitAPIClient.ts
@@ -1,4 +1,4 @@
-import { OrbitAPI, API } from "@withorbit/api";
+import { OrbitAPI, API, OrbitAPIValidator } from "@withorbit/api";
 import {
   Attachment,
   AttachmentID,
@@ -10,6 +10,11 @@ import { APIConfig, defaultAPIConfig } from "./apiConfig";
 import { AuthenticationConfig, RequestManager } from "./requestManager";
 import { Blob } from "./util/fetch";
 
+const ajvValidator = new OrbitAPIValidator({
+  allowUnsupportedRoute: true,
+  mutateWithDefaultValues: false,
+});
+
 export class OrbitAPIClient {
   private requestManager: RequestManager<OrbitAPI.Spec>;
 
@@ -20,6 +25,7 @@ export class OrbitAPIClient {
   ) {
     this.requestManager = new RequestManager<OrbitAPI.Spec>(
       config,
+      ajvValidator,
       authenticateRequest,
     );
   }

--- a/packages/api-client/src/requestManager.test.ts
+++ b/packages/api-client/src/requestManager.test.ts
@@ -1,5 +1,5 @@
-import { MockOrbitAPIValidation } from "@withorbit/api";
 import { RequestManager } from "./requestManager";
+import { MockOrbitAPIValidation } from "./util/mockAPIValiation";
 
 const testAPIConfig = { baseURL: "https://localhost" };
 

--- a/packages/api-client/src/requestManager.test.ts
+++ b/packages/api-client/src/requestManager.test.ts
@@ -1,3 +1,4 @@
+import { MockOrbitAPIValidation } from "@withorbit/api";
 import { RequestManager } from "./requestManager";
 
 const testAPIConfig = { baseURL: "https://localhost" };
@@ -17,7 +18,11 @@ describe("URL parameter interpolation", () => {
       GET: { response: void };
     };
   };
-  const requestManager = new RequestManager<TestAPI>(testAPIConfig);
+  const mockedValidator = new MockOrbitAPIValidation();
+  const requestManager = new RequestManager<TestAPI>(
+    testAPIConfig,
+    mockedValidator,
+  );
 
   test("interpolates parameters", () => {
     const url = requestManager.getRequestURL("/foo/:bar/baz/:bat", "GET", {

--- a/packages/api-client/src/util/mockAPIValiation.ts
+++ b/packages/api-client/src/util/mockAPIValiation.ts
@@ -1,4 +1,4 @@
-import { APIValidator } from "./apiValidator";
+import { APIValidator } from "@withorbit/api";
 
 export class MockOrbitAPIValidation implements APIValidator {
   validateRequest(): true {

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -6,10 +6,14 @@
   "types": "./dist/index.d.ts",
   "private": true,
   "scripts": {
-    "build": "tsc -b"
+    "build": "tsc -b",
+    "generateSchema": "typescript-json-schema src/orbitAPI.ts ValidatableSpec -o src/orbitAPISchema.json --noExtraProps --required --ignoreErrors --strictNullChecks"
   },
-  "dependencies": {},
+  "dependencies": {
+    "ajv": "8.4.0"
+  },
   "devDependencies": {
-    "typescript": "^4.2.4"
+    "typescript": "^4.2.4",
+    "typescript-json-schema": "^0.50.0"
   }
 }

--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -1,5 +1,4 @@
 export * as OrbitAPI from "./orbitAPI";
 export * as API from "./genericHTTPAPI";
 export { OrbitAPIValidator } from "./validation/orbitAPIValidator";
-export { MockOrbitAPIValidation } from "./validation/mockAPIValiation";
 export type { APIValidator } from "./validation/apiValidator";

--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -1,2 +1,5 @@
 export * as OrbitAPI from "./orbitAPI";
 export * as API from "./genericHTTPAPI";
+export { OrbitAPIValidator } from "./validation/orbitAPIValidator";
+export { MockOrbitAPIValidation } from "./validation/mockAPIValiation";
+export type { APIValidator } from "./validation/apiValidator";

--- a/packages/api/src/orbitAPI.ts
+++ b/packages/api/src/orbitAPI.ts
@@ -9,9 +9,10 @@ import {
   PromptTaskID,
 } from "@withorbit/core";
 import { BlobLike } from "./genericHTTPAPI";
+import { RequiredSpec } from "./util/requiredSpec";
 
 // Meant to conform to genericHTTPAPI/Spec, but I can't declare conformance without running into obscure Typescript limitations.
-export type Spec = {
+type SpecLegacy = {
   "/taskStates": {
     GET: {
       query:
@@ -27,21 +28,6 @@ export type Spec = {
           ))
         | { ids: PromptTaskID[] };
       response: ResponseList<"taskState", PromptTaskID, PromptState>;
-    };
-  };
-
-  "/actionLogs": {
-    GET: {
-      query: {
-        limit?: number;
-        createdAfterID?: ActionLogID;
-      };
-      response: ResponseList<"actionLog", ActionLogID, ActionLog>;
-    };
-
-    PATCH: {
-      body: { id: ActionLogID; data: ActionLog }[];
-      response: void;
     };
   };
 
@@ -88,6 +74,41 @@ export type Spec = {
     returns application/json encoded ResponseObject<"attachmentIDReference", AttachmentID, AttachmentIDReference>
    */
 };
+
+export type ValidatableSpec = {
+  "/actionLogs"?: {
+    GET?: {
+      query: {
+        /**
+         * @minimum 1
+         * @default 100
+         * @TJS-type integer
+         */
+        limit?: number;
+        /**
+         * Created After ActionLogID
+         * @TJS-type string
+         */
+        createdAfterID?: ActionLogID;
+      };
+      response?: ResponseList<"actionLog", ActionLogID, ActionLog>;
+    };
+
+    PATCH?: {
+      body: {
+        /**
+         * Created After ActionLogID
+         * @TJS-type string
+         */
+        id: ActionLogID;
+        data: ActionLog;
+      }[];
+      response?: null;
+    };
+  };
+};
+
+export type Spec = RequiredSpec<ValidatableSpec> & SpecLegacy;
 
 export type ResponseList<
   ObjectTypeString extends string,

--- a/packages/api/src/orbitAPI.ts
+++ b/packages/api/src/orbitAPI.ts
@@ -85,10 +85,6 @@ export type ValidatableSpec = {
          * @TJS-type integer
          */
         limit?: number;
-        /**
-         * Created After ActionLogID
-         * @TJS-type string
-         */
         createdAfterID?: ActionLogID;
       };
       response?: ResponseList<"actionLog", ActionLogID, ActionLog>;
@@ -96,10 +92,6 @@ export type ValidatableSpec = {
 
     PATCH?: {
       body: {
-        /**
-         * Created After ActionLogID
-         * @TJS-type string
-         */
         id: ActionLogID;
         data: ActionLog;
       }[];
@@ -126,6 +118,9 @@ export type ResponseObject<
   DataType
 > = {
   objectType: ObjectType;
+  /**
+   * @TJS-type string
+   */
   id: IDType;
   data: DataType;
 };

--- a/packages/api/src/orbitAPISchema.json
+++ b/packages/api/src/orbitAPISchema.json
@@ -2,6 +2,40 @@
     "$schema": "http://json-schema.org/draft-07/schema#",
     "additionalProperties": false,
     "definitions": {
+        "IngestActionLog": {
+            "additionalProperties": false,
+            "properties": {
+                "actionLogType": {
+                    "enum": [
+                        "ingest"
+                    ],
+                    "type": "string"
+                },
+                "provenance": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/TaskProvenance"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ]
+                },
+                "taskID": {
+                    "type": "string"
+                },
+                "timestampMillis": {
+                    "type": "number"
+                }
+            },
+            "required": [
+                "actionLogType",
+                "provenance",
+                "taskID",
+                "timestampMillis"
+            ],
+            "type": "object"
+        },
         "Partial<TaskMetadata>": {
             "additionalProperties": false,
             "properties": {
@@ -28,6 +62,105 @@
                 "web"
             ],
             "type": "string"
+        },
+        "RepetitionActionLog": {
+            "additionalProperties": false,
+            "properties": {
+                "actionLogType": {
+                    "enum": [
+                        "repetition"
+                    ],
+                    "type": "string"
+                },
+                "context": {
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                },
+                "outcome": {
+                    "type": "string"
+                },
+                "parentActionLogIDs": {
+                    "items": {
+                        "additionalProperties": false,
+                        "properties": {
+                        },
+                        "type": "object"
+                    },
+                    "type": "array"
+                },
+                "taskID": {
+                    "type": "string"
+                },
+                "taskParameters": {
+                    "anyOf": [
+                        {
+                            "additionalProperties": {
+                                "type": [
+                                    "null",
+                                    "string",
+                                    "number"
+                                ]
+                            },
+                            "type": "object"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ]
+                },
+                "timestampMillis": {
+                    "type": "number"
+                }
+            },
+            "required": [
+                "actionLogType",
+                "context",
+                "outcome",
+                "parentActionLogIDs",
+                "taskID",
+                "taskParameters",
+                "timestampMillis"
+            ],
+            "type": "object"
+        },
+        "RescheduleActionLog": {
+            "additionalProperties": false,
+            "properties": {
+                "actionLogType": {
+                    "enum": [
+                        "reschedule"
+                    ],
+                    "type": "string"
+                },
+                "newTimestampMillis": {
+                    "type": "number"
+                },
+                "parentActionLogIDs": {
+                    "items": {
+                        "additionalProperties": false,
+                        "properties": {
+                        },
+                        "type": "object"
+                    },
+                    "type": "array"
+                },
+                "taskID": {
+                    "type": "string"
+                },
+                "timestampMillis": {
+                    "type": "number"
+                }
+            },
+            "required": [
+                "actionLogType",
+                "newTimestampMillis",
+                "parentActionLogIDs",
+                "taskID",
+                "timestampMillis"
+            ],
+            "type": "object"
         },
         "TaskProvenance": {
             "additionalProperties": false,
@@ -65,6 +198,43 @@
                 "url"
             ],
             "type": "object"
+        },
+        "UpdateMetadataActionLog": {
+            "additionalProperties": false,
+            "properties": {
+                "actionLogType": {
+                    "enum": [
+                        "updateMetadata"
+                    ],
+                    "type": "string"
+                },
+                "parentActionLogIDs": {
+                    "items": {
+                        "additionalProperties": false,
+                        "properties": {
+                        },
+                        "type": "object"
+                    },
+                    "type": "array"
+                },
+                "taskID": {
+                    "type": "string"
+                },
+                "timestampMillis": {
+                    "type": "number"
+                },
+                "updates": {
+                    "$ref": "#/definitions/Partial<TaskMetadata>"
+                }
+            },
+            "required": [
+                "actionLogType",
+                "parentActionLogIDs",
+                "taskID",
+                "timestampMillis",
+                "updates"
+            ],
+            "type": "object"
         }
     },
     "properties": {
@@ -78,8 +248,10 @@
                             "additionalProperties": false,
                             "properties": {
                                 "createdAfterID": {
-                                    "description": "Created After ActionLogID",
-                                    "type": "string"
+                                    "additionalProperties": false,
+                                    "properties": {
+                                    },
+                                    "type": "object"
                                 },
                                 "limit": {
                                     "default": 100,
@@ -99,174 +271,16 @@
                                             "data": {
                                                 "anyOf": [
                                                     {
-                                                        "additionalProperties": false,
-                                                        "properties": {
-                                                            "actionLogType": {
-                                                                "enum": [
-                                                                    "ingest"
-                                                                ],
-                                                                "type": "string"
-                                                            },
-                                                            "provenance": {
-                                                                "anyOf": [
-                                                                    {
-                                                                        "$ref": "#/definitions/TaskProvenance"
-                                                                    },
-                                                                    {
-                                                                        "type": "null"
-                                                                    }
-                                                                ]
-                                                            },
-                                                            "taskID": {
-                                                                "type": "string"
-                                                            },
-                                                            "timestampMillis": {
-                                                                "type": "number"
-                                                            }
-                                                        },
-                                                        "required": [
-                                                            "actionLogType",
-                                                            "provenance",
-                                                            "taskID",
-                                                            "timestampMillis"
-                                                        ],
-                                                        "type": "object"
+                                                        "$ref": "#/definitions/IngestActionLog"
                                                     },
                                                     {
-                                                        "additionalProperties": false,
-                                                        "properties": {
-                                                            "actionLogType": {
-                                                                "enum": [
-                                                                    "repetition"
-                                                                ],
-                                                                "type": "string"
-                                                            },
-                                                            "context": {
-                                                                "type": [
-                                                                    "null",
-                                                                    "string"
-                                                                ]
-                                                            },
-                                                            "outcome": {
-                                                                "type": "string"
-                                                            },
-                                                            "parentActionLogIDs": {
-                                                                "items": {
-                                                                    "additionalProperties": false,
-                                                                    "properties": {
-                                                                    },
-                                                                    "type": "object"
-                                                                },
-                                                                "type": "array"
-                                                            },
-                                                            "taskID": {
-                                                                "type": "string"
-                                                            },
-                                                            "taskParameters": {
-                                                                "anyOf": [
-                                                                    {
-                                                                        "additionalProperties": {
-                                                                            "type": [
-                                                                                "null",
-                                                                                "string",
-                                                                                "number"
-                                                                            ]
-                                                                        },
-                                                                        "type": "object"
-                                                                    },
-                                                                    {
-                                                                        "type": "null"
-                                                                    }
-                                                                ]
-                                                            },
-                                                            "timestampMillis": {
-                                                                "type": "number"
-                                                            }
-                                                        },
-                                                        "required": [
-                                                            "actionLogType",
-                                                            "context",
-                                                            "outcome",
-                                                            "parentActionLogIDs",
-                                                            "taskID",
-                                                            "taskParameters",
-                                                            "timestampMillis"
-                                                        ],
-                                                        "type": "object"
+                                                        "$ref": "#/definitions/RepetitionActionLog"
                                                     },
                                                     {
-                                                        "additionalProperties": false,
-                                                        "properties": {
-                                                            "actionLogType": {
-                                                                "enum": [
-                                                                    "reschedule"
-                                                                ],
-                                                                "type": "string"
-                                                            },
-                                                            "newTimestampMillis": {
-                                                                "type": "number"
-                                                            },
-                                                            "parentActionLogIDs": {
-                                                                "items": {
-                                                                    "additionalProperties": false,
-                                                                    "properties": {
-                                                                    },
-                                                                    "type": "object"
-                                                                },
-                                                                "type": "array"
-                                                            },
-                                                            "taskID": {
-                                                                "type": "string"
-                                                            },
-                                                            "timestampMillis": {
-                                                                "type": "number"
-                                                            }
-                                                        },
-                                                        "required": [
-                                                            "actionLogType",
-                                                            "newTimestampMillis",
-                                                            "parentActionLogIDs",
-                                                            "taskID",
-                                                            "timestampMillis"
-                                                        ],
-                                                        "type": "object"
+                                                        "$ref": "#/definitions/RescheduleActionLog"
                                                     },
                                                     {
-                                                        "additionalProperties": false,
-                                                        "properties": {
-                                                            "actionLogType": {
-                                                                "enum": [
-                                                                    "updateMetadata"
-                                                                ],
-                                                                "type": "string"
-                                                            },
-                                                            "parentActionLogIDs": {
-                                                                "items": {
-                                                                    "additionalProperties": false,
-                                                                    "properties": {
-                                                                    },
-                                                                    "type": "object"
-                                                                },
-                                                                "type": "array"
-                                                            },
-                                                            "taskID": {
-                                                                "type": "string"
-                                                            },
-                                                            "timestampMillis": {
-                                                                "type": "number"
-                                                            },
-                                                            "updates": {
-                                                                "$ref": "#/definitions/Partial<TaskMetadata>"
-                                                            }
-                                                        },
-                                                        "required": [
-                                                            "actionLogType",
-                                                            "parentActionLogIDs",
-                                                            "taskID",
-                                                            "timestampMillis",
-                                                            "updates"
-                                                        ],
-                                                        "type": "object"
+                                                        "$ref": "#/definitions/UpdateMetadataActionLog"
                                                     }
                                                 ]
                                             },
@@ -325,180 +339,24 @@
                                     "data": {
                                         "anyOf": [
                                             {
-                                                "additionalProperties": false,
-                                                "properties": {
-                                                    "actionLogType": {
-                                                        "enum": [
-                                                            "ingest"
-                                                        ],
-                                                        "type": "string"
-                                                    },
-                                                    "provenance": {
-                                                        "anyOf": [
-                                                            {
-                                                                "$ref": "#/definitions/TaskProvenance"
-                                                            },
-                                                            {
-                                                                "type": "null"
-                                                            }
-                                                        ]
-                                                    },
-                                                    "taskID": {
-                                                        "type": "string"
-                                                    },
-                                                    "timestampMillis": {
-                                                        "type": "number"
-                                                    }
-                                                },
-                                                "required": [
-                                                    "actionLogType",
-                                                    "provenance",
-                                                    "taskID",
-                                                    "timestampMillis"
-                                                ],
-                                                "type": "object"
+                                                "$ref": "#/definitions/IngestActionLog"
                                             },
                                             {
-                                                "additionalProperties": false,
-                                                "properties": {
-                                                    "actionLogType": {
-                                                        "enum": [
-                                                            "repetition"
-                                                        ],
-                                                        "type": "string"
-                                                    },
-                                                    "context": {
-                                                        "type": [
-                                                            "null",
-                                                            "string"
-                                                        ]
-                                                    },
-                                                    "outcome": {
-                                                        "type": "string"
-                                                    },
-                                                    "parentActionLogIDs": {
-                                                        "items": {
-                                                            "additionalProperties": false,
-                                                            "properties": {
-                                                            },
-                                                            "type": "object"
-                                                        },
-                                                        "type": "array"
-                                                    },
-                                                    "taskID": {
-                                                        "type": "string"
-                                                    },
-                                                    "taskParameters": {
-                                                        "anyOf": [
-                                                            {
-                                                                "additionalProperties": {
-                                                                    "type": [
-                                                                        "null",
-                                                                        "string",
-                                                                        "number"
-                                                                    ]
-                                                                },
-                                                                "type": "object"
-                                                            },
-                                                            {
-                                                                "type": "null"
-                                                            }
-                                                        ]
-                                                    },
-                                                    "timestampMillis": {
-                                                        "type": "number"
-                                                    }
-                                                },
-                                                "required": [
-                                                    "actionLogType",
-                                                    "context",
-                                                    "outcome",
-                                                    "parentActionLogIDs",
-                                                    "taskID",
-                                                    "taskParameters",
-                                                    "timestampMillis"
-                                                ],
-                                                "type": "object"
+                                                "$ref": "#/definitions/RepetitionActionLog"
                                             },
                                             {
-                                                "additionalProperties": false,
-                                                "properties": {
-                                                    "actionLogType": {
-                                                        "enum": [
-                                                            "reschedule"
-                                                        ],
-                                                        "type": "string"
-                                                    },
-                                                    "newTimestampMillis": {
-                                                        "type": "number"
-                                                    },
-                                                    "parentActionLogIDs": {
-                                                        "items": {
-                                                            "additionalProperties": false,
-                                                            "properties": {
-                                                            },
-                                                            "type": "object"
-                                                        },
-                                                        "type": "array"
-                                                    },
-                                                    "taskID": {
-                                                        "type": "string"
-                                                    },
-                                                    "timestampMillis": {
-                                                        "type": "number"
-                                                    }
-                                                },
-                                                "required": [
-                                                    "actionLogType",
-                                                    "newTimestampMillis",
-                                                    "parentActionLogIDs",
-                                                    "taskID",
-                                                    "timestampMillis"
-                                                ],
-                                                "type": "object"
+                                                "$ref": "#/definitions/RescheduleActionLog"
                                             },
                                             {
-                                                "additionalProperties": false,
-                                                "properties": {
-                                                    "actionLogType": {
-                                                        "enum": [
-                                                            "updateMetadata"
-                                                        ],
-                                                        "type": "string"
-                                                    },
-                                                    "parentActionLogIDs": {
-                                                        "items": {
-                                                            "additionalProperties": false,
-                                                            "properties": {
-                                                            },
-                                                            "type": "object"
-                                                        },
-                                                        "type": "array"
-                                                    },
-                                                    "taskID": {
-                                                        "type": "string"
-                                                    },
-                                                    "timestampMillis": {
-                                                        "type": "number"
-                                                    },
-                                                    "updates": {
-                                                        "$ref": "#/definitions/Partial<TaskMetadata>"
-                                                    }
-                                                },
-                                                "required": [
-                                                    "actionLogType",
-                                                    "parentActionLogIDs",
-                                                    "taskID",
-                                                    "timestampMillis",
-                                                    "updates"
-                                                ],
-                                                "type": "object"
+                                                "$ref": "#/definitions/UpdateMetadataActionLog"
                                             }
                                         ]
                                     },
                                     "id": {
-                                        "description": "Created After ActionLogID",
-                                        "type": "string"
+                                        "additionalProperties": false,
+                                        "properties": {
+                                        },
+                                        "type": "object"
                                     }
                                 },
                                 "required": [

--- a/packages/api/src/orbitAPISchema.json
+++ b/packages/api/src/orbitAPISchema.json
@@ -1,0 +1,527 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "additionalProperties": false,
+    "definitions": {
+        "Partial<TaskMetadata>": {
+            "additionalProperties": false,
+            "properties": {
+                "isDeleted": {
+                    "type": "boolean"
+                },
+                "provenance": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/TaskProvenance"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ]
+                }
+            },
+            "type": "object"
+        },
+        "PromptProvenanceType": {
+            "enum": [
+                "anki",
+                "note",
+                "web"
+            ],
+            "type": "string"
+        },
+        "TaskProvenance": {
+            "additionalProperties": false,
+            "properties": {
+                "externalID": {
+                    "type": "string"
+                },
+                "modificationTimestampMillis": {
+                    "type": [
+                        "null",
+                        "number"
+                    ]
+                },
+                "provenanceType": {
+                    "$ref": "#/definitions/PromptProvenanceType"
+                },
+                "title": {
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                },
+                "url": {
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                }
+            },
+            "required": [
+                "externalID",
+                "modificationTimestampMillis",
+                "provenanceType",
+                "title",
+                "url"
+            ],
+            "type": "object"
+        }
+    },
+    "properties": {
+        "/actionLogs": {
+            "additionalProperties": false,
+            "properties": {
+                "GET": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "query": {
+                            "additionalProperties": false,
+                            "properties": {
+                                "createdAfterID": {
+                                    "description": "Created After ActionLogID",
+                                    "type": "string"
+                                },
+                                "limit": {
+                                    "default": 100,
+                                    "minimum": 1,
+                                    "type": "integer"
+                                }
+                            },
+                            "type": "object"
+                        },
+                        "response": {
+                            "additionalProperties": false,
+                            "properties": {
+                                "data": {
+                                    "items": {
+                                        "additionalProperties": false,
+                                        "properties": {
+                                            "data": {
+                                                "anyOf": [
+                                                    {
+                                                        "additionalProperties": false,
+                                                        "properties": {
+                                                            "actionLogType": {
+                                                                "enum": [
+                                                                    "ingest"
+                                                                ],
+                                                                "type": "string"
+                                                            },
+                                                            "provenance": {
+                                                                "anyOf": [
+                                                                    {
+                                                                        "$ref": "#/definitions/TaskProvenance"
+                                                                    },
+                                                                    {
+                                                                        "type": "null"
+                                                                    }
+                                                                ]
+                                                            },
+                                                            "taskID": {
+                                                                "type": "string"
+                                                            },
+                                                            "timestampMillis": {
+                                                                "type": "number"
+                                                            }
+                                                        },
+                                                        "required": [
+                                                            "actionLogType",
+                                                            "provenance",
+                                                            "taskID",
+                                                            "timestampMillis"
+                                                        ],
+                                                        "type": "object"
+                                                    },
+                                                    {
+                                                        "additionalProperties": false,
+                                                        "properties": {
+                                                            "actionLogType": {
+                                                                "enum": [
+                                                                    "repetition"
+                                                                ],
+                                                                "type": "string"
+                                                            },
+                                                            "context": {
+                                                                "type": [
+                                                                    "null",
+                                                                    "string"
+                                                                ]
+                                                            },
+                                                            "outcome": {
+                                                                "type": "string"
+                                                            },
+                                                            "parentActionLogIDs": {
+                                                                "items": {
+                                                                    "additionalProperties": false,
+                                                                    "properties": {
+                                                                    },
+                                                                    "type": "object"
+                                                                },
+                                                                "type": "array"
+                                                            },
+                                                            "taskID": {
+                                                                "type": "string"
+                                                            },
+                                                            "taskParameters": {
+                                                                "anyOf": [
+                                                                    {
+                                                                        "additionalProperties": {
+                                                                            "type": [
+                                                                                "null",
+                                                                                "string",
+                                                                                "number"
+                                                                            ]
+                                                                        },
+                                                                        "type": "object"
+                                                                    },
+                                                                    {
+                                                                        "type": "null"
+                                                                    }
+                                                                ]
+                                                            },
+                                                            "timestampMillis": {
+                                                                "type": "number"
+                                                            }
+                                                        },
+                                                        "required": [
+                                                            "actionLogType",
+                                                            "context",
+                                                            "outcome",
+                                                            "parentActionLogIDs",
+                                                            "taskID",
+                                                            "taskParameters",
+                                                            "timestampMillis"
+                                                        ],
+                                                        "type": "object"
+                                                    },
+                                                    {
+                                                        "additionalProperties": false,
+                                                        "properties": {
+                                                            "actionLogType": {
+                                                                "enum": [
+                                                                    "reschedule"
+                                                                ],
+                                                                "type": "string"
+                                                            },
+                                                            "newTimestampMillis": {
+                                                                "type": "number"
+                                                            },
+                                                            "parentActionLogIDs": {
+                                                                "items": {
+                                                                    "additionalProperties": false,
+                                                                    "properties": {
+                                                                    },
+                                                                    "type": "object"
+                                                                },
+                                                                "type": "array"
+                                                            },
+                                                            "taskID": {
+                                                                "type": "string"
+                                                            },
+                                                            "timestampMillis": {
+                                                                "type": "number"
+                                                            }
+                                                        },
+                                                        "required": [
+                                                            "actionLogType",
+                                                            "newTimestampMillis",
+                                                            "parentActionLogIDs",
+                                                            "taskID",
+                                                            "timestampMillis"
+                                                        ],
+                                                        "type": "object"
+                                                    },
+                                                    {
+                                                        "additionalProperties": false,
+                                                        "properties": {
+                                                            "actionLogType": {
+                                                                "enum": [
+                                                                    "updateMetadata"
+                                                                ],
+                                                                "type": "string"
+                                                            },
+                                                            "parentActionLogIDs": {
+                                                                "items": {
+                                                                    "additionalProperties": false,
+                                                                    "properties": {
+                                                                    },
+                                                                    "type": "object"
+                                                                },
+                                                                "type": "array"
+                                                            },
+                                                            "taskID": {
+                                                                "type": "string"
+                                                            },
+                                                            "timestampMillis": {
+                                                                "type": "number"
+                                                            },
+                                                            "updates": {
+                                                                "$ref": "#/definitions/Partial<TaskMetadata>"
+                                                            }
+                                                        },
+                                                        "required": [
+                                                            "actionLogType",
+                                                            "parentActionLogIDs",
+                                                            "taskID",
+                                                            "timestampMillis",
+                                                            "updates"
+                                                        ],
+                                                        "type": "object"
+                                                    }
+                                                ]
+                                            },
+                                            "id": {
+                                                "additionalProperties": false,
+                                                "properties": {
+                                                },
+                                                "type": "object"
+                                            },
+                                            "objectType": {
+                                                "enum": [
+                                                    "actionLog"
+                                                ],
+                                                "type": "string"
+                                            }
+                                        },
+                                        "required": [
+                                            "data",
+                                            "id",
+                                            "objectType"
+                                        ],
+                                        "type": "object"
+                                    },
+                                    "type": "array"
+                                },
+                                "hasMore": {
+                                    "type": "boolean"
+                                },
+                                "objectType": {
+                                    "enum": [
+                                        "list"
+                                    ],
+                                    "type": "string"
+                                }
+                            },
+                            "required": [
+                                "data",
+                                "hasMore",
+                                "objectType"
+                            ],
+                            "type": "object"
+                        }
+                    },
+                    "required": [
+                        "query"
+                    ],
+                    "type": "object"
+                },
+                "PATCH": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "body": {
+                            "items": {
+                                "additionalProperties": false,
+                                "properties": {
+                                    "data": {
+                                        "anyOf": [
+                                            {
+                                                "additionalProperties": false,
+                                                "properties": {
+                                                    "actionLogType": {
+                                                        "enum": [
+                                                            "ingest"
+                                                        ],
+                                                        "type": "string"
+                                                    },
+                                                    "provenance": {
+                                                        "anyOf": [
+                                                            {
+                                                                "$ref": "#/definitions/TaskProvenance"
+                                                            },
+                                                            {
+                                                                "type": "null"
+                                                            }
+                                                        ]
+                                                    },
+                                                    "taskID": {
+                                                        "type": "string"
+                                                    },
+                                                    "timestampMillis": {
+                                                        "type": "number"
+                                                    }
+                                                },
+                                                "required": [
+                                                    "actionLogType",
+                                                    "provenance",
+                                                    "taskID",
+                                                    "timestampMillis"
+                                                ],
+                                                "type": "object"
+                                            },
+                                            {
+                                                "additionalProperties": false,
+                                                "properties": {
+                                                    "actionLogType": {
+                                                        "enum": [
+                                                            "repetition"
+                                                        ],
+                                                        "type": "string"
+                                                    },
+                                                    "context": {
+                                                        "type": [
+                                                            "null",
+                                                            "string"
+                                                        ]
+                                                    },
+                                                    "outcome": {
+                                                        "type": "string"
+                                                    },
+                                                    "parentActionLogIDs": {
+                                                        "items": {
+                                                            "additionalProperties": false,
+                                                            "properties": {
+                                                            },
+                                                            "type": "object"
+                                                        },
+                                                        "type": "array"
+                                                    },
+                                                    "taskID": {
+                                                        "type": "string"
+                                                    },
+                                                    "taskParameters": {
+                                                        "anyOf": [
+                                                            {
+                                                                "additionalProperties": {
+                                                                    "type": [
+                                                                        "null",
+                                                                        "string",
+                                                                        "number"
+                                                                    ]
+                                                                },
+                                                                "type": "object"
+                                                            },
+                                                            {
+                                                                "type": "null"
+                                                            }
+                                                        ]
+                                                    },
+                                                    "timestampMillis": {
+                                                        "type": "number"
+                                                    }
+                                                },
+                                                "required": [
+                                                    "actionLogType",
+                                                    "context",
+                                                    "outcome",
+                                                    "parentActionLogIDs",
+                                                    "taskID",
+                                                    "taskParameters",
+                                                    "timestampMillis"
+                                                ],
+                                                "type": "object"
+                                            },
+                                            {
+                                                "additionalProperties": false,
+                                                "properties": {
+                                                    "actionLogType": {
+                                                        "enum": [
+                                                            "reschedule"
+                                                        ],
+                                                        "type": "string"
+                                                    },
+                                                    "newTimestampMillis": {
+                                                        "type": "number"
+                                                    },
+                                                    "parentActionLogIDs": {
+                                                        "items": {
+                                                            "additionalProperties": false,
+                                                            "properties": {
+                                                            },
+                                                            "type": "object"
+                                                        },
+                                                        "type": "array"
+                                                    },
+                                                    "taskID": {
+                                                        "type": "string"
+                                                    },
+                                                    "timestampMillis": {
+                                                        "type": "number"
+                                                    }
+                                                },
+                                                "required": [
+                                                    "actionLogType",
+                                                    "newTimestampMillis",
+                                                    "parentActionLogIDs",
+                                                    "taskID",
+                                                    "timestampMillis"
+                                                ],
+                                                "type": "object"
+                                            },
+                                            {
+                                                "additionalProperties": false,
+                                                "properties": {
+                                                    "actionLogType": {
+                                                        "enum": [
+                                                            "updateMetadata"
+                                                        ],
+                                                        "type": "string"
+                                                    },
+                                                    "parentActionLogIDs": {
+                                                        "items": {
+                                                            "additionalProperties": false,
+                                                            "properties": {
+                                                            },
+                                                            "type": "object"
+                                                        },
+                                                        "type": "array"
+                                                    },
+                                                    "taskID": {
+                                                        "type": "string"
+                                                    },
+                                                    "timestampMillis": {
+                                                        "type": "number"
+                                                    },
+                                                    "updates": {
+                                                        "$ref": "#/definitions/Partial<TaskMetadata>"
+                                                    }
+                                                },
+                                                "required": [
+                                                    "actionLogType",
+                                                    "parentActionLogIDs",
+                                                    "taskID",
+                                                    "timestampMillis",
+                                                    "updates"
+                                                ],
+                                                "type": "object"
+                                            }
+                                        ]
+                                    },
+                                    "id": {
+                                        "description": "Created After ActionLogID",
+                                        "type": "string"
+                                    }
+                                },
+                                "required": [
+                                    "data",
+                                    "id"
+                                ],
+                                "type": "object"
+                            },
+                            "type": "array"
+                        },
+                        "response": {
+                            "type": "null"
+                        }
+                    },
+                    "required": [
+                        "body"
+                    ],
+                    "type": "object"
+                }
+            },
+            "type": "object"
+        }
+    },
+    "type": "object"
+}
+

--- a/packages/api/src/orbitAPISchema.json
+++ b/packages/api/src/orbitAPISchema.json
@@ -83,10 +83,7 @@
                 },
                 "parentActionLogIDs": {
                     "items": {
-                        "additionalProperties": false,
-                        "properties": {
-                        },
-                        "type": "object"
+                        "type": "string"
                     },
                     "type": "array"
                 },
@@ -139,10 +136,7 @@
                 },
                 "parentActionLogIDs": {
                     "items": {
-                        "additionalProperties": false,
-                        "properties": {
-                        },
-                        "type": "object"
+                        "type": "string"
                     },
                     "type": "array"
                 },
@@ -210,10 +204,7 @@
                 },
                 "parentActionLogIDs": {
                     "items": {
-                        "additionalProperties": false,
-                        "properties": {
-                        },
-                        "type": "object"
+                        "type": "string"
                     },
                     "type": "array"
                 },
@@ -248,10 +239,7 @@
                             "additionalProperties": false,
                             "properties": {
                                 "createdAfterID": {
-                                    "additionalProperties": false,
-                                    "properties": {
-                                    },
-                                    "type": "object"
+                                    "type": "string"
                                 },
                                 "limit": {
                                     "default": 100,
@@ -285,10 +273,7 @@
                                                 ]
                                             },
                                             "id": {
-                                                "additionalProperties": false,
-                                                "properties": {
-                                                },
-                                                "type": "object"
+                                                "type": "string"
                                             },
                                             "objectType": {
                                                 "enum": [
@@ -353,10 +338,7 @@
                                         ]
                                     },
                                     "id": {
-                                        "additionalProperties": false,
-                                        "properties": {
-                                        },
-                                        "type": "object"
+                                        "type": "string"
                                     }
                                 },
                                 "required": [

--- a/packages/api/src/util/requiredSpec.ts
+++ b/packages/api/src/util/requiredSpec.ts
@@ -1,0 +1,31 @@
+/**
+ * Converts a nested Spec object with optional HTTP methods and routes to be required. For example:
+ * ```
+ * type Spec = RequiredSpec<{
+ *  "/hello"?: {
+ *    GET?: {
+ *      query: { name: string };
+ *      response?: string;
+ *    }
+ *  }
+ * }>
+ * // is equivalent too
+ * type Spec = RequiredSpec<{
+ *  "/hello": {
+ *    GET: {
+ *      query: { name: string };
+ *      response: string;
+ *    }
+ *  }
+ * }>
+ * ```
+ */
+export type RequiredSpec<T> = Required<NestedRequired<T>>;
+
+type NestedRequired<T> = {
+  [P in keyof T]: Required<NestedRequiredWithoutRecursion<T[P]>>;
+};
+
+type NestedRequiredWithoutRecursion<T> = {
+  [P in keyof T]: Required<T[P]>;
+};

--- a/packages/api/src/validation/apiValidator.ts
+++ b/packages/api/src/validation/apiValidator.ts
@@ -1,0 +1,18 @@
+export type APIValidatorRequest = {
+  method: string;
+  path: string;
+  query?: unknown;
+  body?: unknown;
+};
+
+export type APIValidatorError = {
+  errors: { message: string }[];
+};
+
+export interface APIValidator {
+  validateRequest(request: APIValidatorRequest): APIValidatorError | true;
+  validateResponse(
+    request: APIValidatorRequest,
+    response: unknown,
+  ): APIValidatorError | true;
+}

--- a/packages/api/src/validation/mockAPIValiation.ts
+++ b/packages/api/src/validation/mockAPIValiation.ts
@@ -1,0 +1,11 @@
+import { APIValidator } from "./apiValidator";
+
+export class MockOrbitAPIValidation implements APIValidator {
+  validateRequest(): true {
+    return true;
+  }
+
+  validateResponse(): true {
+    return true;
+  }
+}

--- a/packages/api/src/validation/orbitAPIValidator.ts
+++ b/packages/api/src/validation/orbitAPIValidator.ts
@@ -24,6 +24,7 @@ export class OrbitAPIValidator implements APIValidator {
     const ajv = new Ajv({
       allowUnionTypes: true,
       useDefaults: config.mutateWithDefaultValues,
+      coerceTypes: true,
     });
     this.validator = ajv.compile<ValidatableSpec>(OrbitAPISchema);
   }

--- a/packages/api/tsconfig.json
+++ b/packages/api/tsconfig.json
@@ -4,5 +4,10 @@
     "outDir": "./dist",
     "rootDir": "./src"
   },
-  "include": ["./src/**/*.ts"]
+  "include": ["./src/**/*.ts"],
+  "references": [
+    {
+      "path": "../core"
+    }
+  ]
 }

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -17,12 +17,12 @@
   },
   "license": "AGPL-3.0-or-later OR BUSL-1.1",
   "dependencies": {
-    "@withorbit/core": "0.0.1",
-    "@withorbit/api": "0.0.1",
-    "@withorbit/firebase-support": "0.0.1",
     "@google-cloud/bigquery": "^5.5.0",
     "@google-cloud/pubsub": "^2.6.0",
     "@ipld/dag-json": "^4.0.0",
+    "@withorbit/api": "0.0.1",
+    "@withorbit/core": "0.0.1",
+    "@withorbit/firebase-support": "0.0.1",
     "busboy": "^0.3.1",
     "cookie-parser": "^1.4.5",
     "cors": "^2.8.5",
@@ -45,7 +45,6 @@
     "node": "14"
   },
   "devDependencies": {
-    "@withorbit/sample-data": "0.0.1",
     "@babel/core": "^7.12.3",
     "@babel/plugin-transform-modules-commonjs": "^7.12.1",
     "@babel/preset-env": "^7.12.1",
@@ -63,6 +62,7 @@
     "@types/request-ip": "^0.0.35",
     "@typescript-eslint/eslint-plugin": "^4.7.0",
     "@typescript-eslint/parser": "^4.7.0",
+    "@withorbit/sample-data": "0.0.1",
     "babel-jest": "^26.6.3",
     "babel-loader": "^8.1.0",
     "babel-plugin-add-import-extension": "^1.4.3",

--- a/packages/backend/src/api.ts
+++ b/packages/backend/src/api.ts
@@ -1,4 +1,4 @@
-import { OrbitAPI } from "@withorbit/api";
+import { OrbitAPI, OrbitAPIValidator } from "@withorbit/api";
 import cookieParser from "cookie-parser";
 import express from "express";
 import { listActionLogs, storeActionLogs } from "./api/actionLogs";
@@ -13,6 +13,7 @@ import { listTaskData, storeTaskData } from "./api/taskData";
 import { listTaskStates } from "./api/taskStates";
 import corsHandler from "./api/util/corsHandler";
 import createTypedRouter from "./api/util/typedRouter";
+import { validateRequest } from "./util/validateRequest";
 
 const traceAPICall: express.RequestHandler = (request, _, next) => {
   console.log(
@@ -22,6 +23,11 @@ const traceAPICall: express.RequestHandler = (request, _, next) => {
   );
   next();
 };
+
+const routeValidator = new OrbitAPIValidator({
+  allowUnsupportedRoute: true,
+  mutateWithDefaultValues: true,
+});
 
 export function createAPIApp(): express.Application {
   const app = express();
@@ -36,6 +42,7 @@ export function createAPIApp(): express.Application {
     next();
   });
   app.use(traceAPICall);
+  app.use(validateRequest(routeValidator));
 
   createTypedRouter<OrbitAPI.Spec>(app, {
     "/actionLogs": {

--- a/packages/backend/src/api/actionLogs.ts
+++ b/packages/backend/src/api/actionLogs.ts
@@ -11,10 +11,7 @@ export const listActionLogs: TypedRouteHandler<
   "GET"
 > = authenticatedRequestHandler(async (request, userID) => {
   const { query } = request;
-  // TODO HACK: need real type-safe parsing...
-  if (typeof query.limit === "string") {
-    query.limit = Number.parseInt(query.limit);
-  }
+
   const actionLogs = await backend.actionLogs.listActionLogs(userID, {
     limit: 100,
     ...query,

--- a/packages/backend/src/util/validateRequest.ts
+++ b/packages/backend/src/util/validateRequest.ts
@@ -8,8 +8,6 @@ export const validateRequest: CurriedMiddleware = (validator) => (
   res,
   next,
 ) => {
-  convertNumbersToPrimitiveType(req.query);
-
   const validationResult = validator.validateRequest({
     method: req.method,
     path: req.path,
@@ -23,13 +21,3 @@ export const validateRequest: CurriedMiddleware = (validator) => (
     res.status(400).send(validationResult);
   }
 };
-
-function convertNumbersToPrimitiveType(object: Record<string, unknown>) {
-  for (const [key, val] of Object.entries(object)) {
-    if (typeof val !== "string") continue;
-
-    if (!isNaN(Number(val))) {
-      object[key] = Number(val);
-    }
-  }
-}

--- a/packages/backend/src/util/validateRequest.ts
+++ b/packages/backend/src/util/validateRequest.ts
@@ -1,0 +1,35 @@
+import express from "express";
+import { APIValidator } from "@withorbit/api";
+
+type CurriedMiddleware = (validator: APIValidator) => express.RequestHandler;
+
+export const validateRequest: CurriedMiddleware = (validator) => (
+  req,
+  res,
+  next,
+) => {
+  convertNumbersToPrimitiveType(req.query);
+
+  const validationResult = validator.validateRequest({
+    method: req.method,
+    path: req.path,
+    query: req.query,
+    body: req.body,
+  });
+
+  if (validationResult === true) {
+    next();
+  } else {
+    res.status(400).send(validationResult);
+  }
+};
+
+function convertNumbersToPrimitiveType(object: Record<string, unknown>) {
+  for (const [key, val] of Object.entries(object)) {
+    if (typeof val !== "string") continue;
+
+    if (!isNaN(Number(val))) {
+      object[key] = Number(val);
+    }
+  }
+}

--- a/packages/core/src/actionLogID/actionLogID.ts
+++ b/packages/core/src/actionLogID/actionLogID.ts
@@ -142,7 +142,16 @@ function canonicalizeActionLog(actionLog: ActionLog): CIDEncodable<ActionLog> {
   }
 }
 
-export type ActionLogID = string & { __actionLogIDOpaqueType: never };
+// without creating a boxed type the typescript-json-schema will not
+// generate the correct type
+interface BoxActionLogID {
+  id: string & { __actionLogIDOpaqueType: never };
+}
+
+/**
+ * @TJS-type string
+ */
+export type ActionLogID = BoxActionLogID["id"];
 
 export async function getIDForActionLog(
   actionLog: ActionLog,

--- a/packages/core/src/types/actionLog.ts
+++ b/packages/core/src/types/actionLog.ts
@@ -1,44 +1,53 @@
 import { ActionLogID } from "../actionLogID";
 import { TaskMetadata, TaskProvenance } from "./taskMetadata";
 
-export type BaseActionLog = {
+export interface BaseActionLog {
   timestampMillis: number;
   taskID: string;
-};
+}
 
 export type ActionLogMetadata = { [key: string]: string | number | null };
 
 export const ingestActionLogType = "ingest";
-export type IngestActionLog = {
+export interface IngestActionLog extends BaseActionLog {
   actionLogType: typeof ingestActionLogType;
   provenance: TaskProvenance | null;
-} & BaseActionLog;
+}
 
 export const repetitionActionLogType = "repetition";
-export type RepetitionActionLog = {
+export interface RepetitionActionLog extends BaseActionLog {
   actionLogType: typeof repetitionActionLogType;
+  /**
+   * @items.type string
+   */
   parentActionLogIDs: ActionLogID[];
   taskParameters: ActionLogMetadata | null;
 
   outcome: string;
   context: string | null;
-} & BaseActionLog;
+}
 
 export const rescheduleActionLogType = "reschedule";
-export type RescheduleActionLog = {
+export interface RescheduleActionLog extends BaseActionLog {
   actionLogType: typeof rescheduleActionLogType;
+  /**
+   * @items.type string
+   */
   parentActionLogIDs: ActionLogID[];
 
   newTimestampMillis: number;
-} & BaseActionLog;
+}
 
 export const updateMetadataActionLogType = "updateMetadata";
-export type UpdateMetadataActionLog = {
+export interface UpdateMetadataActionLog extends BaseActionLog {
   actionLogType: typeof updateMetadataActionLogType;
+  /**
+   * @items.type string
+   */
   parentActionLogIDs: ActionLogID[];
 
   updates: Partial<TaskMetadata>;
-} & BaseActionLog;
+}
 
 export type ActionLog =
   | IngestActionLog

--- a/yarn.lock
+++ b/yarn.lock
@@ -7491,6 +7491,11 @@
   resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.6.tgz#f4c7ec43e81b319a9815115031709f26987891f0"
   integrity sha512-3c+yGKvVP5Y9TYBEibGNR+kLtijnj7mYrXRg+WpFb2X9xm04g/DXYkfg4hmzJQosc9snFNUPkbYIhu+KAm6jJw==
 
+"@types/json-schema@^7.0.7":
+  version "7.0.7"
+  resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.7.tgz#98a993516c859eb0d5c4c8f098317a9ea68db9ad"
+  integrity sha512-cxWFQVseBm6O9Gbw1IWb8r6OS4OhSt3hPZLkFApLjM8TEXROBuQGLAH2i2gZpcXdLBIrpXuTDhH7Vbm1iXmNGA==
+
 "@types/json5@^0.0.29":
   version "0.0.29"
   resolved "https://registry.yarnpkg.com/@types/json5/-/json5-0.0.29.tgz#ee28707ae94e11d2b827bcbe5270bcea7f3e71ee"
@@ -7655,6 +7660,11 @@
   version "13.13.21"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-13.13.21.tgz#e48d3c2e266253405cf404c8654d1bcf0d333e5c"
   integrity sha512-tlFWakSzBITITJSxHV4hg4KvrhR/7h3xbJdSFbYJBVzKubrASbnnIFuSgolUh7qKGo/ZeJPKUfbZ0WS6Jp14DQ==
+
+"@types/node@^14.14.33":
+  version "14.14.45"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-14.14.45.tgz#ec2dfb5566ff814d061aef7e141575aedba245cf"
+  integrity sha512-DssMqTV9UnnoxDWu959sDLZzfvqCF0qDNRjaWeYSui9xkFe61kKo4l1TWNTQONpuXEm+gLMRvdlzvNHBamzmEw==
 
 "@types/node@^7.0.31":
   version "7.10.13"
@@ -8613,6 +8623,16 @@ ajv-keywords@^3.1.0, ajv-keywords@^3.4.1, ajv-keywords@^3.5.2:
   version "3.5.2"
   resolved "https://registry.yarnpkg.com/ajv-keywords/-/ajv-keywords-3.5.2.tgz#31f29da5ab6e00d1c2d329acf7b5929614d5014d"
   integrity sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==
+
+ajv@8.4.0:
+  version "8.4.0"
+  resolved "https://registry.yarnpkg.com/ajv/-/ajv-8.4.0.tgz#48984fdb2ce225cab15795f0772a8d85669075e4"
+  integrity sha512-7QD2l6+KBSLwf+7MuYocbWvRPdOu63/trReTLu2KFwkgctnub1auoF+Y1WYcm09CTM7quuscrzqmASaLHC/K4Q==
+  dependencies:
+    fast-deep-equal "^3.1.1"
+    json-schema-traverse "^1.0.0"
+    require-from-string "^2.0.2"
+    uri-js "^4.2.2"
 
 ajv@^6.1.0, ajv@^6.10.0, ajv@^6.10.2, ajv@^6.12.4, ajv@^6.12.5:
   version "6.12.6"
@@ -12139,6 +12159,11 @@ create-react-context@0.3.0, create-react-context@^0.3.0:
   dependencies:
     gud "^1.0.0"
     warning "^4.0.3"
+
+create-require@^1.1.0:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/create-require/-/create-require-1.1.1.tgz#c1d7e8f1e5f6cfc9ff65f9cd352d37348756c333"
+  integrity sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==
 
 cross-env@^5.1.3:
   version "5.2.1"
@@ -18808,6 +18833,11 @@ json-schema-traverse@^0.4.1:
   version "0.4.1"
   resolved "https://registry.yarnpkg.com/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz#69f6a87d9513ab8bb8fe63bdb0979c448e684660"
   integrity sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==
+
+json-schema-traverse@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz#ae7bcb3656ab77a73ba5c49bf654f38e6b6860e2"
+  integrity sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==
 
 json-schema@0.2.3:
   version "0.2.3"
@@ -27047,6 +27077,18 @@ ts-node@^9.0.0:
     source-map-support "^0.5.17"
     yn "3.1.1"
 
+ts-node@^9.1.1:
+  version "9.1.1"
+  resolved "https://registry.yarnpkg.com/ts-node/-/ts-node-9.1.1.tgz#51a9a450a3e959401bda5f004a72d54b936d376d"
+  integrity sha512-hPlt7ZACERQGf03M253ytLY3dHbGNGrAq9qIHWUY9XHYl1z7wYngSr3OQ5xmui8o2AaxsONxIzjafLUiWBo1Fg==
+  dependencies:
+    arg "^4.1.0"
+    create-require "^1.1.0"
+    diff "^4.0.1"
+    make-error "^1.1.1"
+    source-map-support "^0.5.17"
+    yn "3.1.1"
+
 ts-pnp@^1.1.6:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/ts-pnp/-/ts-pnp-1.2.0.tgz#a500ad084b0798f1c3071af391e65912c86bca92"
@@ -27208,7 +27250,20 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
-typescript@^4.2.4:
+typescript-json-schema@^0.50.0:
+  version "0.50.0"
+  resolved "https://registry.yarnpkg.com/typescript-json-schema/-/typescript-json-schema-0.50.0.tgz#4a78b6b0eca0cfcd518ccfbacef4575ee50c2e45"
+  integrity sha512-53X6J+Mgf/4P9qkPnLM0tkfbGMzjL2MDSsMvpO5MKyZOMp//Widup3oJS9Su9GnIme01ki7LARCPh6Y0Ej14iQ==
+  dependencies:
+    "@types/json-schema" "^7.0.7"
+    "@types/node" "^14.14.33"
+    glob "^7.1.6"
+    json-stable-stringify "^1.0.1"
+    ts-node "^9.1.1"
+    typescript "^4.2.3"
+    yargs "^16.2.0"
+
+typescript@^4.2.3, typescript@^4.2.4:
   version "4.2.4"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.2.4.tgz#8610b59747de028fda898a8aef0e103f156d0961"
   integrity sha512-V+evlYHZnQkaz8TRBuxTA92yZBPotr5H+WhQ7bD3hZUndx5tGOa1fuCgeSjxAzM1RiN5IzvadIXTVefuuwZCRg==
@@ -29010,6 +29065,11 @@ y18n@^5.0.2:
   resolved "https://registry.yarnpkg.com/y18n/-/y18n-5.0.5.tgz#8769ec08d03b1ea2df2500acef561743bbb9ab18"
   integrity sha512-hsRUr4FFrvhhRH12wOdfs38Gy7k2FFzB9qgN9v3aLykRq0dRcdcpz5C9FxdS2NuhOrI/628b/KSTJ3rwHysYSg==
 
+y18n@^5.0.5:
+  version "5.0.8"
+  resolved "https://registry.yarnpkg.com/y18n/-/y18n-5.0.8.tgz#7f4934d0f7ca8c56f95314939ddcd2dd91ce1d55"
+  integrity sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==
+
 yallist@^2.1.2:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/yallist/-/yallist-2.1.2.tgz#1c11f9218f076089a47dd512f93c6699a6a81d52"
@@ -29127,6 +29187,19 @@ yargs@^16.1.0:
     require-directory "^2.1.1"
     string-width "^4.2.0"
     y18n "^5.0.2"
+    yargs-parser "^20.2.2"
+
+yargs@^16.2.0:
+  version "16.2.0"
+  resolved "https://registry.yarnpkg.com/yargs/-/yargs-16.2.0.tgz#1c82bf0f6b6a66eafce7ef30e376f49a12477f66"
+  integrity sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==
+  dependencies:
+    cliui "^7.0.2"
+    escalade "^3.1.1"
+    get-caller-file "^2.0.5"
+    require-directory "^2.1.1"
+    string-width "^4.2.0"
+    y18n "^5.0.5"
     yargs-parser "^20.2.2"
 
 yn@3.1.1:


### PR DESCRIPTION
Related: #184 

This PR looks to add validation to the `/actionLogs` endpoint as part of the ongoing effort to add validation across the app. To accomplish this, a JSON schema is generated based on a portion of the API spec (defined by `ValidatableSpec`). JSON schema was chosen since it extends well to the typescript environment and can create constraints that Typescript cannot (i.e. integer type constraint and much more!). This allows the endpoint to focus on the business logic instead of worrying about validation. Using this format will also allow for public facing documentation to be generated with ease.

## Testing Methodology
<details>
  <summary>Manuel Integration-ish tests (expand for error messages example)</summary>

#### [GET] `/actionLogs`
**it does not allow limit to be a negative integer**
Request: 
```
[GET] http://localhost:5001/metabook-system/us-central1/api/actionLogs?limit=-5
```

Response:
```
{
  "errors": [
    {
      "message": "query/properties/limit/minimum should be >= 1"
    }
  ]
}
```

**it does not allow limit to be a floating point**
Request:
```
[GET] http://localhost:5001/metabook-system/us-central1/api/actionLogs?limit=5.4
```
Response:
```
{
    "errors": [
        {
            "message": "query/properties/limit/type should be integer"
        }
    ]
}
```

**it does not allow createdAfterID to be a string**
Request:
```
[GET] http://localhost:5001/metabook-system/us-central1/api/actionLogs?createdAfterID=2
```

Response:
```
{
    "errors": [
        {
            "message": "query/properties/createdAfterID/type should be string"
        }
    ]
}
```

**it succeeds**
Request:
```
[GET] http://localhost:5001/metabook-system/us-central1/api/actionLogs?createdAfterID="someId"&limit=1000
```

Response:
```
401 Unauthorized  (validation middleware completed without any issues)
```


#### [PATCH] `/actionLogs`

**it fails when extra properties are provided**
Request:
```
[PATCH] http://localhost:5001/metabook-system/us-central1/api/actionLogs
[{
    "id": "someId",
    "data": {
        "timestampMillis": 15,
        "taskID": "12",
        "actionLogType": "ingest",
        "provenance": null
    },
    "someExtraProperty": true
}]
```
Response:
```
{
    "errors": [
        {
            "message": "body/items/additionalProperties should NOT have additional properties"
        }
    ]
}
```

**it fails when actionLogType is invalid**
Request:
```
[PATCH] http://localhost:5001/metabook-system/us-central1/api/actionLogs
[{
    "id": "someId",
    "data": {
        "timestampMillis": 15,
        "taskID": "12",
        "actionLogType": "invalid_action_log_type",
        "provenance": null
    }
}]
```
Response:
```
{
    "errors": [
        {
            "message": "body/items/properties/data/anyOf/0/properties/actionLogType/enum should be equal to one of the allowed values"
        },
        {
            "message": "body/items/properties/data/anyOf/1/additionalProperties should NOT have additional properties"
        },
        {
            "message": "body/items/properties/data/anyOf/2/additionalProperties should NOT have additional properties"
        },
        {
            "message": "body/items/properties/data/anyOf/3/additionalProperties should NOT have additional properties"
        },
        {
            "message": "body/items/properties/data/anyOf should match some schema in anyOf"
        }
    ]
}
```

**it succeeds**
Request:
```
[PATCH] http://localhost:5001/metabook-system/us-central1/api/actionLogs
[{
    "id": "someId",
    "data": {
        "timestampMillis": 15,
        "taskID": "12",
        "actionLogType": "ingest",
        "provenance": null
    }
}]
```
Response:
```
401 Unauthorized  (validation middleware completed without any issues)
```
</details>

Ran the iOS app to make sure there were no warnings being printed from the api-client.

## Tradeoffs
- Error messages are not great and can be confusing when dealing with union types. For example, see the case of the invalid `actionLogType` value. The ajv compiler detects that the type is not valid, however it also flags that the schema does not match any of the other possible definitions. Basically, its ability to narrow the type across union types is not great.
- This current solution might be tricky to extend to dynamic endpoints like `/attachments/:id`. Not sure how to handle this case at the moment.