### PR TITLE
Add tests to OrbitAPIValidator

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "scripts": {
     "build": "tsc -b packages/tsconfig.json",
     "watch": "tsc -b -w packages/tsconfig.json",
-    "test": "cd packages; npx jest --projects anki-import api-client backend core firebase-support web-component note-sync --runInBand",
+    "test": "cd packages; npx jest --projects anki-import api-client backend core firebase-support web-component note-sync api --runInBand",
     "test:watch": "yarn run test --watch",
     "lint": "cd packages; eslint .",
     "lint:fix": "cd packages; eslint --fix ."

--- a/packages/api/babel.config.cjs
+++ b/packages/api/babel.config.cjs
@@ -1,0 +1,14 @@
+// babel.config.js
+module.exports = {
+  presets: [
+    [
+      "@babel/preset-env",
+      {
+        targets: {
+          node: "current",
+        },
+      },
+    ],
+    "@babel/preset-typescript",
+  ],
+};

--- a/packages/api/jest.config.cjs
+++ b/packages/api/jest.config.cjs
@@ -1,0 +1,15 @@
+module.exports = {
+  testEnvironment: "node",
+  testMatch: ["**/?(*.)+(spec|test).ts?(x)"],
+  testPathIgnorePatterns: ["dist", "node_modules"],
+  transformIgnorePatterns: [],
+  transform: {
+    "\\.[jt]s$": ["babel-jest", { cwd: __dirname }],
+  },
+  // Jest struggles to read these mappings from the multiformats packages, which seem to be specifying them just fine as far as I can tell.
+  moduleNameMapper: {
+    "^multiformats$": "multiformats/cjs/src/index.js",
+    "^multiformats/(.+)$": "multiformats/cjs/src/$1.js",
+    "^@ipld/dag-json": "@ipld/dag-json/cjs/index.js",
+  },
+};

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -7,12 +7,16 @@
   "private": true,
   "scripts": {
     "build": "tsc -b",
+    "test": "jest --runInBand",
     "generateSchema": "typescript-json-schema src/orbitAPI.ts ValidatableSpec -o src/orbitAPISchema.json --noExtraProps --required --ignoreErrors --strictNullChecks"
   },
   "dependencies": {
     "ajv": "8.4.0"
   },
   "devDependencies": {
+    "@types/jest": "^26.0.23",
+    "babel-jest": "^26.6.3",
+    "jest": "^26.6.3",
     "typescript": "^4.2.4",
     "typescript-json-schema": "^0.50.0"
   }

--- a/packages/api/src/validation/ajvAPIValidator.test.ts
+++ b/packages/api/src/validation/ajvAPIValidator.test.ts
@@ -145,4 +145,29 @@ describe("AjvAPIValidator", () => {
       errors: [{ message: "query/properties/limit/type must be integer" }],
     });
   });
+
+  it("coerces integer type from string values", () => {
+    const query = { limit: "3" };
+    const result = validator.validateResponse(
+      {
+        path: "/basket",
+        method: "GET",
+        query,
+      },
+      [{ isSliced: true }],
+    );
+    expect(result).toEqual(true);
+  });
+
+  it("coerces boolean type from string values", () => {
+    const result = validator.validateResponse(
+      {
+        path: "/basket",
+        method: "GET",
+        query: {},
+      },
+      [{ isSliced: "true" }],
+    );
+    expect(result).toEqual(true);
+  });
 });

--- a/packages/api/src/validation/ajvAPIValidator.test.ts
+++ b/packages/api/src/validation/ajvAPIValidator.test.ts
@@ -1,0 +1,148 @@
+import { Schema } from "ajv";
+import { AjvAPIValidator } from "./ajvAPIValidator";
+
+type Apple = { isSliced: boolean };
+type Flour = { mass: number };
+type MockSpec = {
+  "/basket": {
+    GET: {
+      query: { limit: number };
+      response: (Apple | Flour)[];
+    };
+  };
+};
+
+const mockSchema: Schema = {
+  $schema: "http://json-schema.org/draft-07/schema#",
+  type: "object",
+  additionalProperties: false,
+  properties: {
+    "/basket": {
+      type: "object",
+      additionalProperties: false,
+      properties: {
+        GET: {
+          type: "object",
+          additionalProperties: false,
+          properties: {
+            query: {
+              type: "object",
+              additionalProperties: false,
+              properties: {
+                limit: {
+                  default: 100,
+                  minimum: 1,
+                  type: "integer",
+                },
+              },
+            },
+            response: {
+              type: "array",
+              items: {
+                anyOf: [
+                  {
+                    type: "object",
+                    additionalProperties: false,
+                    properties: {
+                      isSliced: { type: "boolean" },
+                    },
+                  },
+                  {
+                    type: "object",
+                    additionalProperties: false,
+                    properties: {
+                      mass: { type: "number" },
+                    },
+                  },
+                ],
+              },
+            },
+          },
+        },
+      },
+    },
+  },
+};
+
+describe("AjvAPIValidator", () => {
+  const config = {
+    allowUnsupportedRoute: true,
+    mutateWithDefaultValues: true,
+  };
+  const validator = new AjvAPIValidator<MockSpec>(config, mockSchema);
+
+  it("mutates request query with default value", () => {
+    const query = {};
+    const result = validator.validateRequest({
+      path: "/basket",
+      method: "GET",
+      query,
+    });
+    expect(result).toEqual(true);
+    expect(query).toEqual({ limit: 100 });
+  });
+
+  it("mutates response query with default value", () => {
+    const query = {};
+    const result = validator.validateResponse(
+      {
+        path: "/basket",
+        method: "GET",
+        query,
+      },
+      [{ isSliced: true }],
+    );
+    expect(result).toEqual(true);
+    expect(query).toEqual({ limit: 100 });
+  });
+
+  it("allows unsupported routes when the option is enabled", () => {
+    const result = validator.validateRequest({
+      path: "/someRandomRoute",
+      method: "GET",
+      query: {},
+    });
+    expect(result).toEqual(true);
+  });
+
+  it("fails for unsupported routes when the option is enabled", () => {
+    const doNotAllowUnsupportedRoute = new AjvAPIValidator<MockSpec>(
+      { ...config, allowUnsupportedRoute: false },
+      mockSchema,
+    );
+    const result = doNotAllowUnsupportedRoute.validateRequest({
+      path: "/someRandomRoute",
+      method: "GET",
+      query: {},
+    });
+    expect(result).toEqual({
+      errors: [{ message: " must NOT have additional properties" }],
+    });
+  });
+
+  it("fails for unsupported methods", () => {
+    const result = validator.validateRequest({
+      path: "/basket",
+      method: "POST",
+      query: {},
+    });
+    expect(result).toEqual({
+      errors: [{ message: " must NOT have additional properties" }],
+    });
+  });
+
+  it("strips error message instance path", () => {
+    const query = { limit: 3.14 };
+    const result = validator.validateResponse(
+      {
+        path: "/basket",
+        method: "GET",
+        query,
+      },
+      [{ isSliced: true }],
+    );
+    expect(result).toEqual({
+      errors: [{ message: "query/properties/limit/type must be integer" }],
+    });
+  });
+});

--- a/packages/api/src/validation/ajvAPIValidator.ts
+++ b/packages/api/src/validation/ajvAPIValidator.ts
@@ -1,0 +1,87 @@
+import Ajv, {
+  ErrorObject as AjvErrorObject,
+  Schema as AjvSchema,
+  ValidateFunction as AjvValidationFunction,
+} from "ajv";
+import {
+  APIValidatorRequest,
+  APIValidatorError,
+  APIValidator,
+} from "./apiValidator";
+
+export type AjvAPIValidatorConfig = {
+  mutateWithDefaultValues: boolean;
+  allowUnsupportedRoute: boolean;
+};
+
+export class AjvAPIValidator<T extends AjvSchema> implements APIValidator {
+  private readonly validator: AjvValidationFunction;
+  private readonly config: AjvAPIValidatorConfig;
+
+  constructor(config: AjvAPIValidatorConfig, schema: AjvSchema) {
+    this.config = config;
+    const ajv = new Ajv({
+      allowUnionTypes: true,
+      useDefaults: config.mutateWithDefaultValues,
+      coerceTypes: true,
+    });
+    this.validator = ajv.compile<T>(schema);
+  }
+
+  validateRequest(request: APIValidatorRequest): APIValidatorError | true {
+    return this.validate(request, undefined);
+  }
+
+  validateResponse(
+    request: APIValidatorRequest,
+    response: unknown,
+  ): APIValidatorError | true {
+    return this.validate(request, response);
+  }
+
+  private validate(
+    { method, path, query, body }: APIValidatorRequest,
+    response: unknown,
+  ) {
+    const isValid = this.validator({
+      [path]: {
+        [method]: {
+          ...(method === "GET" ? { query } : { body: body }),
+          response,
+        },
+      },
+    });
+
+    if (
+      isValid ||
+      (this.config.allowUnsupportedRoute && this._isUnsupportedRoute())
+    ) {
+      return true;
+    } else if (this.validator.errors) {
+      return {
+        errors: this.validator.errors.map(this._createAPIValidationError),
+      };
+    } else {
+      return {
+        errors: [{ message: "An unknown validation error occurred" }],
+      };
+    }
+  }
+
+  private _isUnsupportedRoute(): boolean {
+    if (this.validator.errors) {
+      return this.validator.errors[0].schemaPath === "#/additionalProperties";
+    }
+    return false;
+  }
+
+  private _createAPIValidationError(error: AjvErrorObject) {
+    // Assume the format is /#/properties/[HTTP_PATH]/properties/[VERB]/properties/query/*;
+    // strip everything up to query
+    const isolatedInstancePath = error.schemaPath.split("/").slice(6).join("/");
+
+    return {
+      message: `${isolatedInstancePath} ${error.message}`,
+    };
+  }
+}

--- a/packages/api/src/validation/orbitAPIValidator.ts
+++ b/packages/api/src/validation/orbitAPIValidator.ts
@@ -1,88 +1,9 @@
 import { ValidatableSpec } from "@withorbit/api/src/orbitAPI";
 import OrbitAPISchema from "@withorbit/api/src/orbitAPISchema.json";
-import Ajv, {
-  ErrorObject as AjvErrorObject,
-  ValidateFunction as AjvValidationFunction,
-} from "ajv";
-import {
-  APIValidatorRequest,
-  APIValidatorError,
-  APIValidator,
-} from "./apiValidator";
+import { AjvAPIValidator, AjvAPIValidatorConfig } from "./ajvAPIValidator";
 
-type OrbitAPIValidatorConfig = {
-  mutateWithDefaultValues: boolean;
-  allowUnsupportedRoute: boolean;
-};
-
-export class OrbitAPIValidator implements APIValidator {
-  private readonly validator: AjvValidationFunction;
-  private readonly config: OrbitAPIValidatorConfig;
-
-  constructor(config: OrbitAPIValidatorConfig) {
-    this.config = config;
-    const ajv = new Ajv({
-      allowUnionTypes: true,
-      useDefaults: config.mutateWithDefaultValues,
-      coerceTypes: true,
-    });
-    this.validator = ajv.compile<ValidatableSpec>(OrbitAPISchema);
-  }
-
-  validateRequest(request: APIValidatorRequest): APIValidatorError | true {
-    return this.validate(request, undefined);
-  }
-
-  validateResponse(
-    request: APIValidatorRequest,
-    response: unknown,
-  ): APIValidatorError | true {
-    return this.validate(request, response);
-  }
-
-  private validate(
-    { method, path, query, body }: APIValidatorRequest,
-    response: unknown,
-  ) {
-    const isValid = this.validator({
-      [path]: {
-        [method]: {
-          ...(method === "GET" ? { query } : { body: body }),
-          response,
-        },
-      },
-    });
-
-    if (
-      isValid ||
-      (this.config.allowUnsupportedRoute && this._isUnsupportedRoute())
-    ) {
-      return true;
-    } else if (this.validator.errors) {
-      return {
-        errors: this.validator.errors.map(this._createAPIValidationError),
-      };
-    } else {
-      return {
-        errors: [{ message: "An unknown validation error occurred" }],
-      };
-    }
-  }
-
-  private _isUnsupportedRoute(): boolean {
-    if (this.validator.errors) {
-      return this.validator.errors[0].schemaPath === "#/additionalProperties";
-    }
-    return false;
-  }
-
-  private _createAPIValidationError(error: AjvErrorObject) {
-    // Assume the format is /#/properties/[HTTP_PATH]/properties/[VERB]/properties/query/*;
-    // strip everything up to query
-    const isolatedInstancePath = error.schemaPath.split("/").slice(6).join("/");
-
-    return {
-      message: `${isolatedInstancePath} ${error.message}`,
-    };
+export class OrbitAPIValidator extends AjvAPIValidator<ValidatableSpec> {
+  constructor(config: AjvAPIValidatorConfig) {
+    super(config, OrbitAPISchema);
   }
 }

--- a/packages/api/tsconfig.json
+++ b/packages/api/tsconfig.json
@@ -2,7 +2,8 @@
   "extends": "../tsconfig.base.json",
   "compilerOptions": {
     "outDir": "./dist",
-    "rootDir": "./src"
+    "rootDir": "./src",
+    "types": ["jest"]
   },
   "include": ["./src/**/*.ts"],
   "references": [

--- a/yarn.lock
+++ b/yarn.lock
@@ -7486,6 +7486,14 @@
     jest-diff "^26.0.0"
     pretty-format "^26.0.0"
 
+"@types/jest@^26.0.23":
+  version "26.0.23"
+  resolved "https://registry.yarnpkg.com/@types/jest/-/jest-26.0.23.tgz#a1b7eab3c503b80451d019efb588ec63522ee4e7"
+  integrity sha512-ZHLmWMJ9jJ9PTiT58juykZpL7KjwJywFN3Rr2pTSkyQfydf/rk22yS7W8p5DaVUMQ2BQC7oYiU3FjbTM/mYrOA==
+  dependencies:
+    jest-diff "^26.0.0"
+    pretty-format "^26.0.0"
+
 "@types/json-schema@*", "@types/json-schema@^7.0.3", "@types/json-schema@^7.0.5", "@types/json-schema@^7.0.6":
   version "7.0.6"
   resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.6.tgz#f4c7ec43e81b319a9815115031709f26987891f0"


### PR DESCRIPTION
Add a few test cases to the OrbitAPIValidator introduced in https://github.com/andymatuschak/orbit/pull/208. It required setting up `jest` for the `api` package. 