### PR TITLE
Simplify ActionLogID annotations and add an action to make sure api schema is not stale

### DIFF
--- a/.github/workflows/ts.yml
+++ b/.github/workflows/ts.yml
@@ -55,6 +55,8 @@ jobs:
           node-version: 14.x
       - name: "install dependencies"
         run: yarn install
+      - name: "run build"
+        run: "yarn build"
       - name: "run generateSchema"
         working-directory: packages/api
         run: "yarn generateSchema"

--- a/.github/workflows/ts.yml
+++ b/.github/workflows/ts.yml
@@ -45,7 +45,7 @@ jobs:
       - name: "run test"
         run: "yarn test"
   stale-api-schema:
-    name: API schema is up to date
+    name: Generated API schema matches source interfaces
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/ts.yml
+++ b/.github/workflows/ts.yml
@@ -44,3 +44,19 @@ jobs:
         run: "yarn build"
       - name: "run test"
         run: "yarn test"
+  stale-api-schema:
+    name: API schema is up to date
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Use Node.js 14.x
+        uses: actions/setup-node@v2
+        with:
+          node-version: 14.x
+      - name: "install dependencies"
+        run: yarn install
+      - name: "run generateSchema"
+        working-directory: packages/api
+        run: "yarn generateSchema"
+      - name: "check if changes are pending"
+        run: "git diff --exit-code"

--- a/packages/core/src/actionLogID/actionLogID.ts
+++ b/packages/core/src/actionLogID/actionLogID.ts
@@ -142,16 +142,10 @@ function canonicalizeActionLog(actionLog: ActionLog): CIDEncodable<ActionLog> {
   }
 }
 
-// without creating a boxed type the typescript-json-schema will not
-// generate the correct type
-interface BoxActionLogID {
-  id: string & { __actionLogIDOpaqueType: never };
-}
-
 /**
  * @TJS-type string
  */
-export type ActionLogID = BoxActionLogID["id"];
+export type ActionLogID = string & { __actionLogIDOpaqueType: never };
 
 export async function getIDForActionLog(
   actionLog: ActionLog,

--- a/packages/core/src/types/actionLog.ts
+++ b/packages/core/src/types/actionLog.ts
@@ -17,9 +17,6 @@ export interface IngestActionLog extends BaseActionLog {
 export const repetitionActionLogType = "repetition";
 export interface RepetitionActionLog extends BaseActionLog {
   actionLogType: typeof repetitionActionLogType;
-  /**
-   * @items.type string
-   */
   parentActionLogIDs: ActionLogID[];
   taskParameters: ActionLogMetadata | null;
 
@@ -30,9 +27,6 @@ export interface RepetitionActionLog extends BaseActionLog {
 export const rescheduleActionLogType = "reschedule";
 export interface RescheduleActionLog extends BaseActionLog {
   actionLogType: typeof rescheduleActionLogType;
-  /**
-   * @items.type string
-   */
   parentActionLogIDs: ActionLogID[];
 
   newTimestampMillis: number;
@@ -41,9 +35,6 @@ export interface RescheduleActionLog extends BaseActionLog {
 export const updateMetadataActionLogType = "updateMetadata";
 export interface UpdateMetadataActionLog extends BaseActionLog {
   actionLogType: typeof updateMetadataActionLogType;
-  /**
-   * @items.type string
-   */
   parentActionLogIDs: ActionLogID[];
 
   updates: Partial<TaskMetadata>;


### PR DESCRIPTION
Looks like [I was wrong](https://github.com/andymatuschak/orbit/pull/208#discussion_r637335418). Adding an annotation like you mentioned does work. I guess when I tested that solution locally I was running a stale build 🙃.  Anyways, I reverted my type annotations changes.

I also added a Github action to make sure that the API schema is always up to date with the latest code changes.