### PR TITLE
Fix spelling error in homepage docs

### DIFF
--- a/packages/docs/index.html
+++ b/packages/docs/index.html
@@ -196,7 +196,7 @@
       may omit the <code>question</code> or <code>answer</code> attributes if an
       attachment is present. Note that you must supply an absolute URL, not a
       relative URL like <code>/toffoli.png</code>. Your image will be cached on
-      Orbit's servers, and changes to its contents may not propage reliably. If
+      Orbit's servers, and changes to its contents may not propagate reliably. If
       you need to update an image, you should also change its URL.
     </p>
     <p>


### PR DESCRIPTION
Also ran the rest of the doc through spell-check. That appears to be the only spelling error.