### PR TITLE
Add 'continue with user' option when credentials are already present

### DIFF
--- a/packages/app/src/authentication/authenticationClient.ts
+++ b/packages/app/src/authentication/authenticationClient.ts
@@ -10,6 +10,7 @@ export interface AuthenticationClient<LoginToken = unknown, IDToken = unknown> {
   getUserAuthState(): Promise<UserRecord | null>;
 
   signInWithEmailAndPassword(email: string, password: string): Promise<unknown>;
+  signOut(): Promise<unknown>;
 
   createUserWithEmailAndPassword(
     email: string,

--- a/packages/app/src/authentication/firebaseAuthenticationClient.ts
+++ b/packages/app/src/authentication/firebaseAuthenticationClient.ts
@@ -92,6 +92,11 @@ export default class FirebaseAuthenticationClient
     return auth.signInWithEmailAndPassword(email, password);
   }
 
+  async signOut() {
+    const auth = await this.auth();
+    await auth.signOut();
+  }
+
   async createUserWithEmailAndPassword(email: string, password: string) {
     const auth = await this.auth();
     return auth.createUserWithEmailAndPassword(email, password);

--- a/packages/app/src/signIn/SignInScreen.tsx
+++ b/packages/app/src/signIn/SignInScreen.tsx
@@ -1,4 +1,9 @@
-import { SignInForm, SignInFormProps, styles } from "@withorbit/ui";
+import {
+  ContinueWithUser,
+  SignInForm,
+  SignInFormProps,
+  styles,
+} from "@withorbit/ui";
 import React from "react";
 import { ActivityIndicator, Alert, Platform, View } from "react-native";
 import { AuthenticationClient } from "../authentication";
@@ -80,6 +85,10 @@ export default function SignInScreen() {
   const [isPendingServerResponse, setPendingServerResponse] = React.useState(
     false,
   );
+  const [
+    shouldDoubleCheckAccountStatus,
+    setShouldDoubleCheckAccountStatus,
+  ] = React.useState<"requiresUserApproval" | "approved" | null>(null);
 
   // If we have an override email address, figure out whether that account exists.
   React.useEffect(() => {
@@ -95,11 +104,22 @@ export default function SignInScreen() {
   }, [authenticationClient, overrideEmailAddress]);
 
   const userRecord = useCurrentUserRecord(authenticationClient);
+
+  React.useEffect(() => {
+    if (userRecord && shouldDoubleCheckAccountStatus === null) {
+      // a user record was received before the user entered their credentials
+      // lets double check they want to use this account
+      setShouldDoubleCheckAccountStatus("requiresUserApproval");
+    }
+  }, [userRecord, shouldDoubleCheckAccountStatus]);
+
   React.useEffect(() => {
     if (userRecord) {
       const tokenTarget = getCurrentLoginTokenTarget();
       if (tokenTarget) {
-        sendTokenToTargetAndClose(authenticationClient, tokenTarget);
+        if (shouldDoubleCheckAccountStatus === "approved") {
+          sendTokenToTargetAndClose(authenticationClient, tokenTarget);
+        }
       } else {
         if (Platform.OS === "web") {
           // TODO: redirect somewhere useful outside the embedded case
@@ -114,11 +134,12 @@ export default function SignInScreen() {
         }
       }
     }
-  }, [authenticationClient, userRecord]);
+  }, [authenticationClient, userRecord, shouldDoubleCheckAccountStatus]);
 
   const onLogin = React.useCallback(
     async (email, password) => {
       setPendingServerResponse(true);
+      setShouldDoubleCheckAccountStatus("approved");
 
       try {
         switch (formMode) {
@@ -155,6 +176,10 @@ export default function SignInScreen() {
     [authenticationClient],
   );
 
+  const onContinueWithUser = React.useCallback(() => {
+    setShouldDoubleCheckAccountStatus("approved");
+  }, []);
+
   return (
     <View
       style={{
@@ -165,14 +190,22 @@ export default function SignInScreen() {
       }}
     >
       {formMode ? (
-        <SignInForm
-          overrideEmailAddress={overrideEmailAddress}
-          onSubmit={onLogin}
-          onResetPassword={onResetPassword}
-          mode={formMode}
-          isPendingServerResponse={isPendingServerResponse}
-          colorPalette={colorPalette}
-        />
+        shouldDoubleCheckAccountStatus === "requiresUserApproval" ? (
+          <ContinueWithUser
+            colorPalette={colorPalette}
+            email={userRecord?.emailAddress ?? null}
+            onContinueWithUser={onContinueWithUser}
+          />
+        ) : (
+          <SignInForm
+            overrideEmailAddress={overrideEmailAddress}
+            onSubmit={onLogin}
+            onResetPassword={onResetPassword}
+            mode={formMode}
+            isPendingServerResponse={isPendingServerResponse}
+            colorPalette={colorPalette}
+          />
+        )
       ) : (
         <ActivityIndicator size="large" color={colorPalette.accentColor} />
       )}

--- a/packages/app/src/signIn/SignInScreen.tsx
+++ b/packages/app/src/signIn/SignInScreen.tsx
@@ -114,6 +114,13 @@ export default function SignInScreen() {
   }, [userRecord, shouldDoubleCheckAccountStatus]);
 
   React.useEffect(() => {
+    if (userRecord && userRecord.emailAddress !== overrideEmailAddress) {
+      authenticationClient.signOut();
+      setShouldDoubleCheckAccountStatus(null);
+    }
+  }, [authenticationClient, userRecord, overrideEmailAddress]);
+
+  React.useEffect(() => {
     if (userRecord) {
       const tokenTarget = getCurrentLoginTokenTarget();
       if (tokenTarget) {

--- a/packages/ui/src/components/Button.tsx
+++ b/packages/ui/src/components/Button.tsx
@@ -49,6 +49,7 @@ export type ButtonProps = ButtonContents &
 
     numberOfLines?: number;
     ellipsizeMode?: TextProps["ellipsizeMode"];
+    focusOnMount?: boolean;
   };
 
 const pressedButtonOpacity = 0.2;
@@ -196,7 +197,7 @@ const styles = StyleSheet.create({
 
 export default React.memo(function Button(props: ButtonProps) {
   const { onPendingInteractionStateDidChange, style } = props;
-
+  const ref = React.useRef<View | null>(null);
   const href = "href" in props ? props.href : null;
   const onPress = "onPress" in props ? props.onPress : null;
 
@@ -223,6 +224,12 @@ export default React.memo(function Button(props: ButtonProps) {
 
   const isSoloIcon = !("title" in props);
 
+  React.useEffect(() => {
+    if (props.focusOnMount && ref.current) {
+      ref.current.focus();
+    }
+  }, [props.focusOnMount]);
+
   // @ts-ignore
   return (
     <Hoverable
@@ -237,6 +244,7 @@ export default React.memo(function Button(props: ButtonProps) {
     >
       {(isHovered) => (
         <Pressable
+          ref={ref}
           accessible={true}
           accessibilityRole={href ? "link" : "button"}
           accessibilityLabel={accessibilityLabel}

--- a/packages/ui/src/components/ContinueWithUser.stories.tsx
+++ b/packages/ui/src/components/ContinueWithUser.stories.tsx
@@ -1,0 +1,50 @@
+import { Story } from "@storybook/react";
+import React from "react";
+import { View } from "react-native";
+import { colors } from "../styles";
+import ContinueWithUser from "./ContinueWithUser";
+
+export default {
+  title: "ContinueWithUser",
+  component: ContinueWithUser,
+};
+
+const Template: Story<{
+  colorPaletteIndex: number;
+  email: string | null;
+}> = (args) => {
+  const colorPalette =
+    colors.palettes[colors.orderedPaletteNames[args.colorPaletteIndex]];
+
+  const handleContinueWithUser = () => {
+    console.log("Continue with user!");
+  };
+
+  return (
+    <View
+      style={{
+        height: "100vh",
+        backgroundColor: colorPalette.backgroundColor,
+        justifyContent: "center",
+        alignItems: "center",
+      }}
+    >
+      <ContinueWithUser
+        colorPalette={colorPalette}
+        email={args.email}
+        onContinueWithUser={handleContinueWithUser}
+      />
+    </View>
+  );
+};
+
+Template.args = {
+  colorPaletteIndex: 5,
+  email: "test@test.com",
+};
+
+export const Basic = Template.bind({});
+Basic.args = { ...Template.args };
+
+export const InvalidEmail = Template.bind({});
+InvalidEmail.args = { ...Template.args, email: null };

--- a/packages/ui/src/components/ContinueWithUser.stories.tsx
+++ b/packages/ui/src/components/ContinueWithUser.stories.tsx
@@ -11,7 +11,7 @@ export default {
 
 const Template: Story<{
   colorPaletteIndex: number;
-  email: string | null;
+  email: string;
 }> = (args) => {
   const colorPalette =
     colors.palettes[colors.orderedPaletteNames[args.colorPaletteIndex]];
@@ -45,6 +45,3 @@ Template.args = {
 
 export const Basic = Template.bind({});
 Basic.args = { ...Template.args };
-
-export const InvalidEmail = Template.bind({});
-InvalidEmail.args = { ...Template.args, email: null };

--- a/packages/ui/src/components/ContinueWithUser.tsx
+++ b/packages/ui/src/components/ContinueWithUser.tsx
@@ -37,6 +37,7 @@ export default function ContinueWithUser({
               iconName={IconName.ArrowRight}
               title={`Continue`}
               onPress={onContinueWithUser}
+              focusOnMount
             />
           </View>
         </>

--- a/packages/ui/src/components/ContinueWithUser.tsx
+++ b/packages/ui/src/components/ContinueWithUser.tsx
@@ -1,0 +1,68 @@
+import React from "react";
+import { StyleSheet, Text, View } from "react-native";
+import { colors, type, layout } from "../styles";
+import Button from "./Button";
+import { IconName } from "./IconShared";
+import Logo from "./Logo";
+import Spacer from "./Spacer";
+
+export interface ContinueWithUserProps {
+  colorPalette: colors.ColorPalette;
+  email: string | null;
+  onContinueWithUser: () => void;
+}
+
+export default function ContinueWithUser({
+  colorPalette,
+  email,
+  onContinueWithUser,
+}: ContinueWithUserProps) {
+  const flexibleSpacer = <View style={{ flex: 1 }} />;
+
+  return (
+    <View style={styles.container}>
+      {flexibleSpacer}
+      <Logo units={3} tintColor={colorPalette.secondaryTextColor} />
+      <Spacer units={8} />
+      {email ? (
+        <>
+          <Text style={styles.label}>
+            We have found sign in credentials for {email}, would you like to
+            continue with this user?
+          </Text>
+          <Spacer units={3.5} />
+          <View>
+            <Button
+              color={colors.white}
+              accentColor={colorPalette.accentColor}
+              iconName={IconName.ArrowRight}
+              title={`Continue with ${email}`}
+              onPress={onContinueWithUser}
+            />
+          </View>
+        </>
+      ) : (
+        <View>
+          <Text style={styles.label}>
+            An unknown error occurred. A user without an unassociated email has
+            been found.
+          </Text>
+        </View>
+      )}
+      {flexibleSpacer}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    padding: layout.edgeMargin,
+    width: "100%",
+    maxWidth: 375,
+    flex: 1,
+  },
+  label: {
+    ...type.labelSmall.layoutStyle,
+    color: colors.white,
+  },
+});

--- a/packages/ui/src/components/ContinueWithUser.tsx
+++ b/packages/ui/src/components/ContinueWithUser.tsx
@@ -27,8 +27,7 @@ export default function ContinueWithUser({
       {email ? (
         <>
           <Text style={styles.label}>
-            We have found sign in credentials for {email}, would you like to
-            continue with this user?
+            Welcome back, {email}. We signed you in using a saved password.
           </Text>
           <Spacer units={3.5} />
           <View>
@@ -36,7 +35,7 @@ export default function ContinueWithUser({
               color={colors.white}
               accentColor={colorPalette.accentColor}
               iconName={IconName.ArrowRight}
-              title={`Continue with ${email}`}
+              title={`Continue`}
               onPress={onContinueWithUser}
             />
           </View>

--- a/packages/ui/src/components/ContinueWithUser.tsx
+++ b/packages/ui/src/components/ContinueWithUser.tsx
@@ -8,7 +8,7 @@ import Spacer from "./Spacer";
 
 export interface ContinueWithUserProps {
   colorPalette: colors.ColorPalette;
-  email: string | null;
+  email: string;
   onContinueWithUser: () => void;
 }
 
@@ -24,31 +24,20 @@ export default function ContinueWithUser({
       {flexibleSpacer}
       <Logo units={3} tintColor={colorPalette.secondaryTextColor} />
       <Spacer units={8} />
-      {email ? (
-        <>
-          <Text style={styles.label}>
-            Welcome back, {email}. We signed you in using a saved password.
-          </Text>
-          <Spacer units={3.5} />
-          <View>
-            <Button
-              color={colors.white}
-              accentColor={colorPalette.accentColor}
-              iconName={IconName.ArrowRight}
-              title={`Continue`}
-              onPress={onContinueWithUser}
-              focusOnMount
-            />
-          </View>
-        </>
-      ) : (
-        <View>
-          <Text style={styles.label}>
-            An unknown error occurred. A user without an unassociated email has
-            been found.
-          </Text>
-        </View>
-      )}
+      <Text style={styles.label}>
+        Welcome back, {email}. We signed you in using a saved password.
+      </Text>
+      <Spacer units={3.5} />
+      <View>
+        <Button
+          color={colors.white}
+          accentColor={colorPalette.accentColor}
+          iconName={IconName.ArrowRight}
+          title={`Continue`}
+          onPress={onContinueWithUser}
+          focusOnMount
+        />
+      </View>
       {flexibleSpacer}
     </View>
   );

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -9,6 +9,8 @@ export type { ButtonProps } from "./components/Button";
 export { default as Card } from "./components/Card";
 export type { CardProps } from "./components/Card";
 
+export { default as ContinueWithUser } from "./components/ContinueWithUser";
+
 export { default as FadeView } from "./components/FadeView";
 export type { FadeViewProps } from "./components/FadeView";
 


### PR DESCRIPTION
Closes https://github.com/andymatuschak/orbit/issues/179

<p align="center">
<img width="400" src="https://user-images.githubusercontent.com/8084674/120401820-9ce59600-c2f5-11eb-8a1b-f1f25d407992.png">
</p>

**What**
When the credentials are already present on the `iframe`'s domain, a "Continue with <email>" option is shown to confirm with the user that they are already authenticated.

<details>
<summary>Demo of Before and After behaviour</summary>

| Before | After |
| --- | --- |
| ![old_flow](https://user-images.githubusercontent.com/8084674/120401028-ee8d2100-c2f3-11eb-8daa-535e0e03bfed.gif) | ![new_flow](https://user-images.githubusercontent.com/8084674/120401038-f6e55c00-c2f3-11eb-8b3b-c6e7f82686a0.gif) |

</details>

**How**
If the `userRecord` is received before the user has entered their authentication credentials, we'll "double check" that they want to use the account we found. I added a new "ContinueWithUser` component to handle this behaviour to avoid bloating `SigninForm` further with conditionals. 

**Notes**
I will admit this new flow feels a bit "wonky". It feels weird to ask the user to "continue" without presenting them another option. I attempted to add a button that allows the user to "Use a different account", but to do this flow properly would involve reworking how the `overrideEmailAddress` is used right now. If we did want this behaviour, I'd be happy to take that on in a separate PR!

