### PR TITLE
Add keyboard shortcuts for review sessions

### DIFF
--- a/packages/ui/src/components/ReviewArea.tsx
+++ b/packages/ui/src/components/ReviewArea.tsx
@@ -6,7 +6,6 @@ import { colors, layout } from "../styles";
 import { Size } from "../util/Size";
 import Card, { CardProps } from "./Card";
 import FadeView from "./FadeView";
-import useKey from "./hooks/useKey";
 import useLayout from "./hooks/useLayout";
 import usePrevious from "./hooks/usePrevious";
 import { useTransitioningValue } from "./hooks/useTransitioningValue";
@@ -220,34 +219,6 @@ export default React.memo(function ReviewArea({
       ? currentItem?.colorPalette ?? items[items.length - 1].colorPalette
       : colors.palettes.red;
 
-  const onMemoizedMark = useCallback(
-    (outcome: PromptRepetitionOutcome) => {
-      if (!currentItem) {
-        throw new Error("Marking without a topmost item");
-      }
-      onMark({ reviewAreaItem: currentItem, outcome });
-    },
-    [currentItem, onMark],
-  );
-
-  // default action (Space)
-  useKey(" ", () => {
-    if (!isShowingAnswer) {
-      setShowingAnswer(true);
-    } else {
-      onMemoizedMark(PromptRepetitionOutcome.Remembered);
-    }
-  });
-
-  // list of actions (1, 2, 3, ...)
-  const actions = [
-    () => onMemoizedMark(PromptRepetitionOutcome.Forgotten),
-    () => onMemoizedMark(PromptRepetitionOutcome.Remembered),
-  ];
-  actions.forEach((action, index) => {
-    useKey((index + 1).toString(), action, { disabled: !isShowingAnswer });
-  });
-
   return (
     <View style={{ flex: 1 }}>
       <PromptStack
@@ -258,7 +229,15 @@ export default React.memo(function ReviewArea({
 
       <ReviewButtonBar
         colorPalette={currentColorPalette}
-        onMark={onMemoizedMark}
+        onMark={useCallback(
+          (outcome: PromptRepetitionOutcome) => {
+            if (!currentItem) {
+              throw new Error("Marking without a topmost item");
+            }
+            onMark({ reviewAreaItem: currentItem, outcome });
+          },
+          [currentItem, onMark],
+        )}
         onReveal={useCallback(() => {
           setShowingAnswer(true);
         }, [])}

--- a/packages/ui/src/components/ReviewButtonBar.tsx
+++ b/packages/ui/src/components/ReviewButtonBar.tsx
@@ -5,12 +5,13 @@ import {
   PromptRepetitionOutcome,
   PromptType,
 } from "@withorbit/core";
-import React, { useRef } from "react";
+import React, { useRef, useMemo } from "react";
 import { View } from "react-native";
 import { colors, layout } from "../styles";
 import { ColorPalette } from "../styles/colors";
 import unreachableCaseError from "../util/unreachableCaseError";
 import Button, { ButtonPendingActivationState } from "./Button";
+import useKey from "./hooks/useKey";
 import useLayout from "./hooks/useLayout";
 import { IconName } from "./IconShared";
 import Spacer from "./Spacer";
@@ -81,6 +82,22 @@ const ReviewButtonBar = React.memo(function ReviewButtonArea({
 }) {
   const { width, onLayout } = useLayout();
   const isVeryNarrow = width > 0 && width < 320;
+
+  const actions = useMemo(
+    () => [
+      () => onMark(PromptRepetitionOutcome.Forgotten),
+      () => onMark(PromptRepetitionOutcome.Remembered),
+    ],
+    [onMark],
+  );
+
+  // default action (Space)
+  useKey(" ", isShowingAnswer ? actions[1] : onReveal);
+
+  // list of actions (1, 2, 3, ...)
+  actions.forEach((action, index) => {
+    useKey((index + 1).toString(), action, { disabled: !isShowingAnswer });
+  });
 
   const buttonStyle = {
     flex: 1,

--- a/packages/ui/src/components/ReviewButtonBar.tsx
+++ b/packages/ui/src/components/ReviewButtonBar.tsx
@@ -118,7 +118,8 @@ const ReviewButtonBar = React.memo(function ReviewButtonArea({
   useKeyDown((event) => {
     if (
       Object.keys(shortcuts).includes(event.key) &&
-      !shortcuts[event.key].disabled
+      !shortcuts[event.key].disabled &&
+      !event.repeat
     ) {
       shortcuts[event.key].callback();
     }

--- a/packages/ui/src/components/hooks/useKey.ts
+++ b/packages/ui/src/components/hooks/useKey.ts
@@ -1,41 +1,14 @@
-import React from "react";
-import { useEffect } from "react";
+import React, { useEffect } from "react";
 import { Platform } from "react-native";
 
 export type KeyboardEvent = React.KeyboardEvent;
 
-export function useKeyDown(
-  onKeyDown: (event: KeyboardEvent) => void,
-  deps = [] as any[],
-) {
+export function useKeyDown(onKeyDown: (event: KeyboardEvent) => void) {
   useEffect(() => {
-    if (Platform.OS !== "web") return () => {};
+    if (Platform.OS !== "web") return;
 
     document.addEventListener("keydown", onKeyDown);
 
     return () => document.removeEventListener("keydown", onKeyDown);
-  }, [onKeyDown, ...deps]);
-}
-
-interface Options {
-  disabled?: boolean;
-  disableRepeat?: boolean;
-}
-
-export default function useKey(
-  key: string,
-  handler: () => void,
-  options: Options = { disabled: false, disableRepeat: true },
-) {
-  useKeyDown((event) => {
-    if (
-      key !== event.key ||
-      (options.disableRepeat && event.repeat) ||
-      options.disabled
-    ) {
-      return;
-    } else {
-      handler();
-    }
-  });
+  }, [onKeyDown]);
 }

--- a/packages/ui/src/components/hooks/useKey.ts
+++ b/packages/ui/src/components/hooks/useKey.ts
@@ -1,0 +1,41 @@
+import React from "react";
+import { useEffect } from "react";
+import { Platform } from "react-native";
+
+export type KeyboardEvent = React.KeyboardEvent;
+
+export function useKeyDown(
+  onKeyDown: (event: KeyboardEvent) => void,
+  deps = [] as any[],
+) {
+  useEffect(() => {
+    if (Platform.OS !== "web") return () => {};
+
+    document.addEventListener("keydown", onKeyDown);
+
+    return () => document.removeEventListener("keydown", onKeyDown);
+  }, [onKeyDown, ...deps]);
+}
+
+interface Options {
+  disabled?: boolean;
+  disableRepeat?: boolean;
+}
+
+export default function useKey(
+  key: string,
+  handler: () => void,
+  options: Options = { disabled: false, disableRepeat: true },
+) {
+  useKeyDown((event) => {
+    if (
+      key !== event.key ||
+      (options.disableRepeat && event.repeat) ||
+      options.disabled
+    ) {
+      return;
+    } else {
+      handler();
+    }
+  });
+}


### PR DESCRIPTION
Added an `useKey` hook and implemented the default actions (<kbd>Space</kbd>: *Reveal* -> *Remembered*) and <kbd>1</kbd>/<kbd>2</kbd> for the list of actions (*Forgotten* and *Remembered* for now).

Currently there is no hint for the shortcuts. I think we could show it while hovering the buttons.

Also, noticed there is logic for `pendingOutcomeChange` which is called when the user is interacting with one of the actions. Should we call `pendingOutcomeChange` on `keydown` and only call the handlers on `keyup` to make use of this API? If yes, we should probably move the shortcut handling logic inside `Button.tsx`.

> Note: Storybook focuses the sidebar when pressing <kbd>1</kbd> (just keep that in mind while testing).

#165