### PR TITLE
Embed retry questions wording

### DIFF
--- a/packages/app/src/embedded/EmbeddedBanner.tsx
+++ b/packages/app/src/embedded/EmbeddedBanner.tsx
@@ -8,6 +8,7 @@ interface EmbeddedBannerMessageInputs {
   totalPromptCount: number;
   sizeClass: styles.layout.SizeClass;
   wasInitiallyComplete: boolean;
+  isRetryingForgottenItems: boolean;
 }
 
 export interface EmbeddedBannerProps extends EmbeddedBannerMessageInputs {
@@ -20,10 +21,13 @@ function getBannerMessage({
   totalPromptCount,
   sizeClass,
   wasInitiallyComplete,
+  isRetryingForgottenItems,
 }: EmbeddedBannerMessageInputs): string {
   function formatPrompts(n: number): string {
     return n === 1 ? "1 prompt" : `${n} prompts`;
   }
+
+  const suffix = isRetryingForgottenItems ? " (retry)" : "";
 
   if (!isSignedIn && completePromptCount === 0) {
     return sizeClass === "regular"
@@ -34,14 +38,16 @@ function getBannerMessage({
       return `Review complete`;
     } else if (completePromptCount === 0) {
       return sizeClass === "regular"
-        ? `Review session: ${formatPrompts(totalPromptCount)}`
-        : `Review: ${formatPrompts(totalPromptCount)}`;
+        ? `Review session${suffix}: ${formatPrompts(totalPromptCount)}`
+        : `Review${suffix}: ${formatPrompts(totalPromptCount)}`;
     } else if (completePromptCount < totalPromptCount) {
       return sizeClass === "regular"
-        ? `Review session: ${formatPrompts(
+        ? `Review session${suffix}: ${formatPrompts(
             totalPromptCount - completePromptCount,
           )} left`
-        : `${formatPrompts(totalPromptCount - completePromptCount)} left`;
+        : `Review${suffix}: ${formatPrompts(
+            totalPromptCount - completePromptCount,
+          )} left`;
     } else {
       throw new Error("Unreachable");
     }

--- a/packages/app/src/embedded/EmbeddedScreen.tsx
+++ b/packages/app/src/embedded/EmbeddedScreen.tsx
@@ -94,6 +94,7 @@ function EmbeddedScreenRenderer({
   sessionItems,
   reviewAreaQueue,
   wasInitiallyComplete,
+  isRetryingForgottenItems,
 }: EmbeddedScreenRendererProps) {
   const [pendingOutcome, setPendingOutcome] =
     useState<PromptRepetitionOutcome | null>(null);
@@ -165,6 +166,7 @@ function EmbeddedScreenRenderer({
         completePromptCount={currentReviewAreaQueueIndex}
         wasInitiallyComplete={wasInitiallyComplete}
         sizeClass={styles.layout.getWidthSizeClass(containerSize.width)}
+        isRetryingForgottenItems={isRetryingForgottenItems}
       />
       <Animated.View
         onLayout={onInteriorLayout}
@@ -301,6 +303,7 @@ export default function EmbeddedScreen() {
     currentReviewAreaQueueIndex,
     sessionItems,
     reviewAreaQueue,
+    isRetryingForgottenItems,
     ...reviewSessionManager
   } = useReviewSessionManager();
   const { commitActionsRecord, hasUncommittedActions } =
@@ -422,7 +425,7 @@ export default function EmbeddedScreen() {
             hostState,
           );
           console.log("Pushing items to retry", itemsToRetry);
-          reviewSessionManager.pushReviewAreaQueueItems(
+          reviewSessionManager.pushReviewAreaQueueItemsToRetry(
             getEmbeddedReviewAreaItemsFromReviewItems(
               itemsToRetry,
               colorPalette,
@@ -463,6 +466,7 @@ export default function EmbeddedScreen() {
             hasUncommittedActions={hasUncommittedActions}
             isDebug={configuration.isDebug}
             wasInitiallyComplete={wasInitiallyComplete}
+            isRetryingForgottenItems={isRetryingForgottenItems}
           />
         )}
       </ReviewSessionContainer>

--- a/packages/app/src/reviewSession/ReviewSession.tsx
+++ b/packages/app/src/reviewSession/ReviewSession.tsx
@@ -238,7 +238,7 @@ export default function ReviewSession() {
           (item) => !!item.promptState?.needsRetry,
         );
         console.log("Pushing items to retry", itemsToRetry);
-        reviewSessionManager.pushReviewAreaQueueItems(
+        reviewSessionManager.pushReviewAreaQueueItemsToRetry(
           getReviewAreaItemsFromReviewItems(itemsToRetry),
         );
       }


### PR DESCRIPTION
This PR takes a crack at https://github.com/andymatuschak/orbit/issues/174.

It uses a flag (`isRetryingForgottenItems`) to determine whether to show "(retry)" before the number of remaining prompts.

Screenshot:
<img width="498" alt="Screen Shot 2021-07-07 at 11 39 08 PM" src="https://user-images.githubusercontent.com/37984135/124876460-deb1ce00-df7e-11eb-958b-4504587494b9.png">