### PR TITLE
Make provenance links more obvious

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -109,3 +109,6 @@ dist
 # TernJS port file
 .tern-port
 
+# Test notes
+packages/note-sync/testNotes
+packages/note-sync/cache.db

--- a/packages/ui/src/components/Button.tsx
+++ b/packages/ui/src/components/Button.tsx
@@ -25,6 +25,7 @@ export type ButtonPendingActivationState = "hover" | "pressed" | null;
 type ButtonContents =
   | { title: string; iconName?: IconName }
   | { iconName: IconName; accessibilityLabel: string };
+
 type ButtonAction =
   | {
       onPress: () => void;
@@ -42,6 +43,7 @@ export type ButtonProps = ButtonContents &
     hitSlop?: PressableProps["hitSlop"];
 
     style?: StyleProp<FlexStyle>;
+    iconLeftOfTitle?: boolean;
 
     onPendingInteractionStateDidChange?: (
       pendingActivationState: ButtonPendingActivationState,
@@ -67,6 +69,7 @@ const ButtonInterior = function ButtonImpl(
     iconName,
     isHovered,
     isPressed,
+    iconLeftOfTitle,
     ...rest
   } = props;
   const opacity = React.useRef(new Animated.Value(1)).current;
@@ -156,32 +159,34 @@ const ButtonInterior = function ButtonImpl(
             },
         ]}
       >
-        {iconName && (
-          <Icon
-            name={iconName}
-            position={isSoloIcon ? IconPosition.Center : IconPosition.TopLeft}
-            // This is a bit confusing: the button's accent color becomes the icon's tint color; the button's color becomes the icon's accent color. It's intentional, though, to produce an inversion.
-            tintColor={iconColor ?? defaultButtonColor}
-            accentColor={color ?? defaultButtonColor}
-          />
-        )}
-        {"title" in props && (
-          <Text
-            {...rest}
-            style={[
-              (size ?? "regular") === "regular"
-                ? type.label.layoutStyle
-                : type.labelTiny.layoutStyle,
-              {
-                color: titleColor,
-              },
-            ]}
-            selectable={false}
-            suppressHighlighting={true}
-          >
-            {props.title}
-          </Text>
-        )}
+        <div style={iconLeftOfTitle ? { display: "flex" } : {}}>
+          {iconName && (
+            <Icon
+              name={iconName}
+              position={isSoloIcon ? IconPosition.Center : IconPosition.TopLeft}
+              // This is a bit confusing: the button's accent color becomes the icon's tint color; the button's color becomes the icon's accent color. It's intentional, though, to produce an inversion.
+              tintColor={iconColor ?? defaultButtonColor}
+              accentColor={color ?? defaultButtonColor}
+            />
+          )}
+          {"title" in props && (
+            <Text
+              {...rest}
+              style={[
+                (size ?? "regular") === "regular"
+                  ? type.label.layoutStyle
+                  : type.labelTiny.layoutStyle,
+                {
+                  color: titleColor,
+                },
+              ]}
+              selectable={false}
+              suppressHighlighting={true}
+            >
+              {props.title}
+            </Text>
+          )}
+        </div>
       </Animated.View>
     </View>
   );

--- a/packages/ui/src/components/Card.tsx
+++ b/packages/ui/src/components/Card.tsx
@@ -31,6 +31,7 @@ import {
   AnimatedTransitionTiming,
   useTransitioningValue,
 } from "./hooks/useTransitioningValue";
+import { IconName } from "./IconShared";
 import CardField, { clozeBlankSentinel } from "./PromptFieldRenderer";
 
 function getQAPromptContents<PT extends QAPromptTask | ApplicationPromptTask>(
@@ -156,6 +157,7 @@ function PromptContextLabel({
 
   const color = accentColor ?? colors.ink;
   const numberOfLines = size === "regular" ? 3 : 1;
+
   return (
     promptContext && (
       <View style={style}>
@@ -164,6 +166,9 @@ function PromptContextLabel({
             size={size}
             href={promptContext.url}
             title={promptContext.title}
+            iconName={IconName.ArrowRight}
+            iconLeftOfTitle={true}
+            accentColor={accentColor}
             color={color}
             numberOfLines={numberOfLines}
             ellipsizeMode="tail"


### PR DESCRIPTION
Takes a crack at https://github.com/andymatuschak/orbit/issues/172. Right now it does the following:
- Add an optional `iconLeftOfTitle` prop to `Button` to show icon next to the title instead of above.
- Use the above to add a link icon to the provenance link button. There is no link icon in the `assets/icons` folder yet, but if this approach seems okay, we can look for an SVG I guess.
- Add `testNotes` and `cache.db` to `.gitignore` for convenience.

Screenshot:
<img width="497" alt="Screen Shot 2021-07-11 at 10 34 48 PM" src="https://user-images.githubusercontent.com/37984135/125236382-b684e080-e298-11eb-80ca-68269009ac74.png">

Putting it up as a draft to get feedback on whether this feels like the right approach.