### PR TITLE
Fix mismatch between the docs code snippet and the prompts that are displayed

### DIFF
--- a/packages/docs/index.html
+++ b/packages/docs/index.html
@@ -103,8 +103,9 @@
         answer="Orbit"
       &gt;&lt;/orbit-prompt&gt;
       &lt;orbit-prompt
-        question="What's the new-ish web technology used to embed Orbit prompts into web pages?"
-        answer="Web components"
+        question="What kind of quantum gate is this?"
+        question-attachments="https://docs.withorbit.com/toffoli.png"
+        answer="A Toffoli gate."
       &gt;&lt;/orbit-prompt&gt;
       &lt;orbit-prompt
         question="Given a right triangle with legs of length $a$ and $b$, what is the length of hypotenuse $c$?"


### PR DESCRIPTION
Minor update to the HTML code snippet on the docs to make it match the prompts that are displayed.