### PR TITLE
Fix AJV validation is incorrectly permitting extra properties on Events

### DIFF
--- a/packages/api/src/validation/ajvAPIValidator.ts
+++ b/packages/api/src/validation/ajvAPIValidator.ts
@@ -85,7 +85,10 @@ export class AjvAPIValidator<T extends AjvSchema> implements APIValidator {
 
   private _isUnsupportedRoute(): boolean {
     if (this.validator.errors) {
-      return this.validator.errors[0].schemaPath === "#/additionalProperties";
+      return (
+        this.validator.errors[0].instancePath === "" &&
+        this.validator.errors[0].schemaPath == "#/additionalProperties"
+      );
     }
     return false;
   }

--- a/packages/app/src/embedded/EmbeddedScreen.tsx
+++ b/packages/app/src/embedded/EmbeddedScreen.tsx
@@ -52,8 +52,7 @@ import {
 import { useRemoteTaskStates } from "./useRemoteTaskStates";
 import { findItemsToRetry } from "./util/findItemsToRetry";
 import getEmbeddedColorPalette from "./util/getEmbeddedColorPalette";
-import getEmbeddedScreenConfigurationFromURL
-  from "./util/getEmbeddedScreenConfigurationFromURL";
+import getEmbeddedScreenConfigurationFromURL from "./util/getEmbeddedScreenConfigurationFromURL";
 
 function getStarburstItems(sessionItems: ReviewItem[]): ReviewStarburstItem[] {
   return sessionItems.map((item) => {

--- a/packages/backend/src/__tests__/integration/events.test.ts
+++ b/packages/backend/src/__tests__/integration/events.test.ts
@@ -88,8 +88,7 @@ describe("[GET] validation", () => {
 });
 
 describe("[PATCH] validation", () => {
-  // https://github.com/andymatuschak/orbit/issues/236
-  it.skip("it fails when extra properties are provided", async () => {
+  it("it fails when extra properties are provided", async () => {
     const ingestEvent = createTestTaskIngestEvents(1)[0];
     const { status, body } = await fetchRoute(`/api/events`, {
       method: "PATCH",
@@ -102,11 +101,12 @@ describe("[PATCH] validation", () => {
       ],
     });
     expect(status).toBe(400);
-    expect(body.errors).toMatchObject([
-      {
-        message: "body/0 must NOT have additional properties",
-      },
-    ]);
+    expect(
+      body.errors.includes(
+        (e: Error) =>
+          e.message === "body/0 must NOT have additional properties",
+      ),
+    );
   });
 
   it("it fails when actionLogType is invalid", async () => {

--- a/packages/embedded-support/src/ipc.ts
+++ b/packages/embedded-support/src/ipc.ts
@@ -1,5 +1,5 @@
 import { ReviewItem, Task } from "@withorbit/core";
-import { EmbeddedScreenConfiguration } from "../dist";
+import { EmbeddedScreenConfiguration } from ".";
 
 // Messages from host to embedded:
 //================================

--- a/packages/web-component/src/OrbitReviewAreaElement.ts
+++ b/packages/web-component/src/OrbitReviewAreaElement.ts
@@ -1,7 +1,6 @@
 import { ColorPaletteName } from "@withorbit/core";
 import {
   EmbeddedHostEventType,
-  EmbeddedHostInitialConfigurationEvent,
   EmbeddedHostMetadata,
   EmbeddedHostUpdateEvent,
   EmbeddedScreenConfiguration,


### PR DESCRIPTION
Closes https://github.com/andymatuschak/orbit/issues/236

**Problem**: When including an extra property like in the case of the [PATCH `/api/events`](https://github.com/andymatuschak/orbit/blob/master/packages/backend/src/__tests__/integration/events.test.ts#L92) route, the API validator will incorrectly succeed the route despite this property being an obvious validation error.

**Solution**: I believe in the process of updating dependencies recently (maybe https://github.com/andymatuschak/orbit/commit/4eb0828b5ad3b73f3242f436334027347cbc2ab3?), the AJV version upgraded. With newer versions of AJV, a new property `instancePath` is included and the `schemaPath` seems to behave slightly different for nested objects. To fix our issue, we just need to identify that the `instancePath` is the root (i.e. an empty string). 

**Some idle notes**: I have never been too keen on my solution to this unsupported route problem given how fragile it is. One alternative is to identify the routes from the JSON schema (`Object.keys(schema.definitions)`) and then check against this list when trying to determine if the route is supported. That being said, this solution quickly grows in complexity when trying to handle dynamic routes like `/attachments/:id`. 