### PR TITLE
Validate event schema on putEvents

### DIFF
--- a/.github/workflows/ts.yml
+++ b/.github/workflows/ts.yml
@@ -57,8 +57,13 @@ jobs:
         run: yarn install
       - name: "run build"
         run: "yarn build"
-      - name: "run generateSchema"
+      - name: "run generateSchema for the API"
         working-directory: packages/api
+        run: "yarn generateSchema"
+      - name: "check if changes are pending"
+        run: "git diff --exit-code"
+      - name: "run generateSchema for the events validator"
+        working-directory: packages/store-shared
         run: "yarn generateSchema"
       - name: "check if changes are pending"
         run: "git diff --exit-code"

--- a/packages/backend/src/db/firestoreDatabaseBackend.test.ts
+++ b/packages/backend/src/db/firestoreDatabaseBackend.test.ts
@@ -24,10 +24,10 @@ class TestFirestoreDatabaseBackend extends FirestoreDatabaseBackend {
 describe("database tests", () => {
   runDatabaseTests(
     "Firestore",
-    async (eventReducer) => {
+    async (eventReducer, eventValidator) => {
       const currentFirebaseApp = createTestAdminFirebaseApp();
       const backend = new TestFirestoreDatabaseBackend(currentFirebaseApp);
-      return new Database(backend, eventReducer);
+      return new Database(backend, eventReducer, eventValidator);
     },
     false,
   );

--- a/packages/store-fs/src/database.test.ts
+++ b/packages/store-fs/src/database.test.ts
@@ -2,10 +2,11 @@ import { Database, runDatabaseTests } from "@withorbit/store-shared";
 import { SQLDatabaseBackend } from "./sqlite";
 
 describe("database tests", () => {
-  runDatabaseTests("SQLite", async (eventReducer) => {
+  runDatabaseTests("SQLite", async (eventReducer, eventValidator) => {
     return new Database(
       new SQLDatabaseBackend(SQLDatabaseBackend.inMemoryDBSubpath),
       eventReducer,
+      eventValidator,
     );
   });
 });

--- a/packages/store-shared/package.json
+++ b/packages/store-shared/package.json
@@ -9,15 +9,18 @@
   "exports": "./dist/index.js",
   "sideEffects": false,
   "scripts": {
-    "build": "tsc -b"
+    "build": "tsc -b",
+    "generateSchema": "typescript-json-schema src/validation/eventsValidator.ts Events -o src/validation/events.json --noExtraProps --required --ignoreErrors --strictNullChecks"
   },
   "dependencies": {
     "@withorbit/core": "0.0.1",
+    "ajv": "8.6.2",
     "base64-js": "^1.5.1"
   },
   "devDependencies": {
     "@types/base64-js": "^1.3.0",
     "@types/jest": "^26.0.24",
-    "typescript": "^4.2.4"
+    "typescript": "^4.2.4",
+    "typescript-json-schema": "^0.50.1"
   }
 }

--- a/packages/store-shared/src/validation/AjvEventsValidator.ts
+++ b/packages/store-shared/src/validation/AjvEventsValidator.ts
@@ -1,0 +1,35 @@
+import { Event } from "@withorbit/core";
+import { EventsValidator, EventsValidatorError } from "./eventsValidator";
+import Ajv, { ValidateFunction as AjvValidationFunction } from "ajv";
+import DatabaseEventsSchema from "./events.json";
+
+export class AjvEventsValidator implements EventsValidator {
+  private readonly validator: AjvValidationFunction;
+
+  constructor() {
+    const ajv = new Ajv({
+      allowUnionTypes: true,
+      verbose: true,
+    });
+    this.validator = ajv.compile(DatabaseEventsSchema);
+  }
+
+  validateEvents(events: Event[]): EventsValidatorError | true {
+    const isValidTypes = this.validator(events);
+    if (isValidTypes !== true) {
+      if (this.validator.errors) {
+        return {
+          errors: this.validator.errors.map((error) => ({
+            message: `${error.schemaPath} ${error.message}`,
+          })),
+        };
+      } else {
+        return {
+          errors: [{ message: "An unknown validation error occurred" }],
+        };
+      }
+    }
+    // TODO: validate the existence of IDs
+    return true;
+  }
+}

--- a/packages/store-shared/src/validation/events.json
+++ b/packages/store-shared/src/validation/events.json
@@ -1,0 +1,472 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "definitions": {
+        "AttachmentIngestEvent": {
+            "additionalProperties": false,
+            "properties": {
+                "entityID": {
+                    "pattern": "^[0-9a-zA-Z_\\-]{22}$",
+                    "type": "string"
+                },
+                "id": {
+                    "pattern": "^[0-9a-zA-Z_\\-]{22}$",
+                    "type": "string"
+                },
+                "mimeType": {
+                    "$ref": "#/definitions/AttachmentMIMEType"
+                },
+                "timestampMillis": {
+                    "type": "number"
+                },
+                "type": {
+                    "enum": [
+                        "attachmentIngest"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "entityID",
+                "id",
+                "mimeType",
+                "timestampMillis",
+                "type"
+            ],
+            "type": "object"
+        },
+        "AttachmentMIMEType": {
+            "enum": [
+                "image/jpeg",
+                "image/png",
+                "image/svg+xml"
+            ],
+            "type": "string"
+        },
+        "ClozeTaskContent": {
+            "additionalProperties": false,
+            "properties": {
+                "body": {
+                    "$ref": "#/definitions/TaskContentField"
+                },
+                "components": {
+                    "additionalProperties": {
+                        "$ref": "#/definitions/ClozeTaskContentComponent"
+                    },
+                    "type": "object"
+                },
+                "type": {
+                    "enum": [
+                        "cloze"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "body",
+                "components",
+                "type"
+            ],
+            "type": "object"
+        },
+        "ClozeTaskContentComponent": {
+            "additionalProperties": false,
+            "properties": {
+                "order": {
+                    "type": "number"
+                },
+                "ranges": {
+                    "items": {
+                        "additionalProperties": false,
+                        "properties": {
+                            "hint": {
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "length": {
+                                "type": "number"
+                            },
+                            "startIndex": {
+                                "type": "number"
+                            }
+                        },
+                        "required": [
+                            "hint",
+                            "length",
+                            "startIndex"
+                        ],
+                        "type": "object"
+                    },
+                    "type": "array"
+                }
+            },
+            "required": [
+                "order",
+                "ranges"
+            ],
+            "type": "object"
+        },
+        "PlainTaskContent": {
+            "additionalProperties": false,
+            "properties": {
+                "body": {
+                    "$ref": "#/definitions/TaskContentField"
+                },
+                "type": {
+                    "enum": [
+                        "plain"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "body",
+                "type"
+            ],
+            "type": "object"
+        },
+        "QATaskContent": {
+            "additionalProperties": false,
+            "properties": {
+                "answer": {
+                    "$ref": "#/definitions/TaskContentField"
+                },
+                "body": {
+                    "$ref": "#/definitions/TaskContentField"
+                },
+                "type": {
+                    "enum": [
+                        "qa"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "answer",
+                "body",
+                "type"
+            ],
+            "type": "object"
+        },
+        "TaskContentField": {
+            "additionalProperties": false,
+            "properties": {
+                "attachments": {
+                    "items": {
+                        "pattern": "^[0-9a-zA-Z_\\-]{22}$",
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                "text": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "attachments",
+                "text"
+            ],
+            "type": "object"
+        },
+        "TaskIngestEvent": {
+            "additionalProperties": false,
+            "properties": {
+                "entityID": {
+                    "pattern": "^[0-9a-zA-Z_\\-]{22}$",
+                    "type": "string"
+                },
+                "id": {
+                    "pattern": "^[0-9a-zA-Z_\\-]{22}$",
+                    "type": "string"
+                },
+                "metadata": {
+                    "additionalProperties": {
+                        "type": "string"
+                    },
+                    "type": "object"
+                },
+                "provenance": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/TaskProvenance"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ]
+                },
+                "spec": {
+                    "$ref": "#/definitions/TaskSpec<TaskContent>"
+                },
+                "timestampMillis": {
+                    "type": "number"
+                },
+                "type": {
+                    "enum": [
+                        "taskIngest"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "entityID",
+                "id",
+                "provenance",
+                "spec",
+                "timestampMillis",
+                "type"
+            ],
+            "type": "object"
+        },
+        "TaskProvenance": {
+            "additionalProperties": false,
+            "properties": {
+                "colorPaletteName": {
+                    "enum": [
+                        "blue",
+                        "brown",
+                        "cyan",
+                        "green",
+                        "lime",
+                        "orange",
+                        "pink",
+                        "purple",
+                        "red",
+                        "turquoise",
+                        "violet",
+                        "yellow"
+                    ],
+                    "type": "string"
+                },
+                "containerTitle": {
+                    "type": "string"
+                },
+                "identifier": {
+                    "type": "string"
+                },
+                "title": {
+                    "type": "string"
+                },
+                "url": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "identifier"
+            ],
+            "type": "object"
+        },
+        "TaskRepetitionEvent": {
+            "additionalProperties": false,
+            "properties": {
+                "componentID": {
+                    "type": "string"
+                },
+                "entityID": {
+                    "pattern": "^[0-9a-zA-Z_\\-]{22}$",
+                    "type": "string"
+                },
+                "id": {
+                    "pattern": "^[0-9a-zA-Z_\\-]{22}$",
+                    "type": "string"
+                },
+                "outcome": {
+                    "$ref": "#/definitions/TaskRepetitionOutcome"
+                },
+                "reviewSessionID": {
+                    "type": "string"
+                },
+                "timestampMillis": {
+                    "type": "number"
+                },
+                "type": {
+                    "enum": [
+                        "taskRepetition"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "componentID",
+                "entityID",
+                "id",
+                "outcome",
+                "reviewSessionID",
+                "timestampMillis",
+                "type"
+            ],
+            "type": "object"
+        },
+        "TaskRepetitionOutcome": {
+            "enum": [
+                "forgotten",
+                "remembered"
+            ],
+            "type": "string"
+        },
+        "TaskRescheduleEvent": {
+            "additionalProperties": false,
+            "properties": {
+                "componentID": {
+                    "type": "string"
+                },
+                "entityID": {
+                    "pattern": "^[0-9a-zA-Z_\\-]{22}$",
+                    "type": "string"
+                },
+                "id": {
+                    "pattern": "^[0-9a-zA-Z_\\-]{22}$",
+                    "type": "string"
+                },
+                "newDueTimestampMillis": {
+                    "type": "number"
+                },
+                "timestampMillis": {
+                    "type": "number"
+                },
+                "type": {
+                    "enum": [
+                        "taskReschedule"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "componentID",
+                "entityID",
+                "id",
+                "newDueTimestampMillis",
+                "timestampMillis",
+                "type"
+            ],
+            "type": "object"
+        },
+        "TaskSpec<TaskContent>": {
+            "additionalProperties": false,
+            "properties": {
+                "content": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/QATaskContent"
+                        },
+                        {
+                            "$ref": "#/definitions/ClozeTaskContent"
+                        },
+                        {
+                            "$ref": "#/definitions/PlainTaskContent"
+                        }
+                    ]
+                },
+                "type": {
+                    "enum": [
+                        "memory"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "content",
+                "type"
+            ],
+            "type": "object"
+        },
+        "TaskUpdateDeletedEvent": {
+            "additionalProperties": false,
+            "properties": {
+                "entityID": {
+                    "pattern": "^[0-9a-zA-Z_\\-]{22}$",
+                    "type": "string"
+                },
+                "id": {
+                    "pattern": "^[0-9a-zA-Z_\\-]{22}$",
+                    "type": "string"
+                },
+                "isDeleted": {
+                    "type": "boolean"
+                },
+                "timestampMillis": {
+                    "type": "number"
+                },
+                "type": {
+                    "enum": [
+                        "taskUpdatedDeleted"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "entityID",
+                "id",
+                "isDeleted",
+                "timestampMillis",
+                "type"
+            ],
+            "type": "object"
+        },
+        "TaskUpdateProvenanceEvent": {
+            "additionalProperties": false,
+            "properties": {
+                "entityID": {
+                    "pattern": "^[0-9a-zA-Z_\\-]{22}$",
+                    "type": "string"
+                },
+                "id": {
+                    "pattern": "^[0-9a-zA-Z_\\-]{22}$",
+                    "type": "string"
+                },
+                "provenance": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/TaskProvenance"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ]
+                },
+                "timestampMillis": {
+                    "type": "number"
+                },
+                "type": {
+                    "enum": [
+                        "taskUpdateProvenanceEvent"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "entityID",
+                "id",
+                "provenance",
+                "timestampMillis",
+                "type"
+            ],
+            "type": "object"
+        }
+    },
+    "items": {
+        "anyOf": [
+            {
+                "$ref": "#/definitions/TaskIngestEvent"
+            },
+            {
+                "$ref": "#/definitions/TaskRepetitionEvent"
+            },
+            {
+                "$ref": "#/definitions/TaskRescheduleEvent"
+            },
+            {
+                "$ref": "#/definitions/TaskUpdateDeletedEvent"
+            },
+            {
+                "$ref": "#/definitions/TaskUpdateProvenanceEvent"
+            },
+            {
+                "$ref": "#/definitions/AttachmentIngestEvent"
+            }
+        ]
+    },
+    "type": "array"
+}
+

--- a/packages/store-shared/src/validation/eventsValidator.ts
+++ b/packages/store-shared/src/validation/eventsValidator.ts
@@ -1,0 +1,11 @@
+import { Event } from "@withorbit/core";
+
+type Events = Event[];
+
+export type EventsValidatorError = {
+  errors: { message: string }[];
+};
+
+export interface EventsValidator {
+  validateEvents(events: Events): EventsValidatorError | true;
+}

--- a/packages/store-shared/tsconfig.json
+++ b/packages/store-shared/tsconfig.json
@@ -5,7 +5,7 @@
     "rootDir": "./src",
     "types": ["jest"]
   },
-  "include": ["./src/**/*.ts", "./@types/**/*.d.ts"],
+  "include": ["./src/**/*.ts", "./@types/**/*.d.ts", "./src/**/*.json"],
   "references": [
     {
       "path": "../core"

--- a/packages/store-web/src/database.test.ts
+++ b/packages/store-web/src/database.test.ts
@@ -6,10 +6,11 @@ import { IDBDatabaseBackend } from "./indexedDB";
 describe("database tests", () => {
   runDatabaseTests(
     "IndexedDB",
-    async (eventReducer) =>
+    async (eventReducer, eventValidator) =>
       new Database(
         new IDBDatabaseBackend("TestDB", new FDBFactory()),
         eventReducer,
+        eventValidator,
       ),
   );
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -8714,6 +8714,16 @@ ajv-keywords@^3.1.0, ajv-keywords@^3.4.1, ajv-keywords@^3.5.2:
   resolved "https://registry.yarnpkg.com/ajv-keywords/-/ajv-keywords-3.5.2.tgz#31f29da5ab6e00d1c2d329acf7b5929614d5014d"
   integrity sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==
 
+ajv@8.6.2, ajv@^8.6.2:
+  version "8.6.2"
+  resolved "https://registry.yarnpkg.com/ajv/-/ajv-8.6.2.tgz#2fb45e0e5fcbc0813326c1c3da535d1881bb0571"
+  integrity sha512-9807RlWAgT564wT+DjeyU5OFMPjmzxVobvDFmNAhY+5zD6A2ly3jDp6sgnfyDtlIQ+7H97oc/DGCzzfu9rjw9w==
+  dependencies:
+    fast-deep-equal "^3.1.1"
+    json-schema-traverse "^1.0.0"
+    require-from-string "^2.0.2"
+    uri-js "^4.2.2"
+
 ajv@^6.1.0, ajv@^6.10.0, ajv@^6.10.2, ajv@^6.12.4, ajv@^6.12.5, ajv@^6.12.6:
   version "6.12.6"
   resolved "https://registry.yarnpkg.com/ajv/-/ajv-6.12.6.tgz#baf5a62e802b07d977034586f8c3baf5adf26df4"
@@ -8732,16 +8742,6 @@ ajv@^6.12.2, ajv@^6.12.3:
     fast-deep-equal "^3.1.1"
     fast-json-stable-stringify "^2.0.0"
     json-schema-traverse "^0.4.1"
-    uri-js "^4.2.2"
-
-ajv@^8.6.2:
-  version "8.6.2"
-  resolved "https://registry.yarnpkg.com/ajv/-/ajv-8.6.2.tgz#2fb45e0e5fcbc0813326c1c3da535d1881bb0571"
-  integrity sha512-9807RlWAgT564wT+DjeyU5OFMPjmzxVobvDFmNAhY+5zD6A2ly3jDp6sgnfyDtlIQ+7H97oc/DGCzzfu9rjw9w==
-  dependencies:
-    fast-deep-equal "^3.1.1"
-    json-schema-traverse "^1.0.0"
-    require-from-string "^2.0.2"
     uri-js "^4.2.2"
 
 alphanum-sort@^1.0.0:
@@ -27341,12 +27341,25 @@ typescript-json-schema@^0.50.0:
     typescript "^4.2.3"
     yargs "^16.2.0"
 
+typescript-json-schema@^0.50.1:
+  version "0.50.1"
+  resolved "https://registry.yarnpkg.com/typescript-json-schema/-/typescript-json-schema-0.50.1.tgz#48041eb9f6efbdf4ba88c3e3af9433601f7a2b47"
+  integrity sha512-GCof/SDoiTDl0qzPonNEV4CHyCsZEIIf+mZtlrjoD8vURCcEzEfa2deRuxYid8Znp/e27eDR7Cjg8jgGrimBCA==
+  dependencies:
+    "@types/json-schema" "^7.0.7"
+    "@types/node" "^14.14.33"
+    glob "^7.1.6"
+    json-stable-stringify "^1.0.1"
+    ts-node "^9.1.1"
+    typescript "~4.2.3"
+    yargs "^16.2.0"
+
 typescript@^4.0.0:
   version "4.3.5"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.3.5.tgz#4d1c37cc16e893973c45a06886b7113234f119f4"
   integrity sha512-DqQgihaQ9cUrskJo9kIyW/+g0Vxsk8cDtZ52a3NGh0YNTfpUSArXSohyUGnvbPazEPLu398C0UxmKSOrPumUzA==
 
-typescript@^4.2.3, typescript@^4.2.4:
+typescript@^4.2.3, typescript@^4.2.4, typescript@~4.2.3:
   version "4.2.4"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.2.4.tgz#8610b59747de028fda898a8aef0e103f156d0961"
   integrity sha512-V+evlYHZnQkaz8TRBuxTA92yZBPotr5H+WhQ7bD3hZUndx5tGOa1fuCgeSjxAzM1RiN5IzvadIXTVefuuwZCRg==


### PR DESCRIPTION
Closes https://github.com/andymatuschak/orbit/issues/240

**What does this do?**
Validates at runtime that the `events` parameter on `database.putEvents` has the correct schema.

**Why?**
SQLite and IndexedDB do not validate the schema before any mutation. Thus, if the schema is incorrect, the users local database might move into a bad state and making it impossible to sync.

**How?**
Using a similar validation strategy as the API, a JSON schema was generated for the `Event[]` type. This schema is used to verify that the `events` parameter of `putEvents` is valid at runtime (thanks to `Ajv`)