### PR TITLE
ui/Tooltip - basic implementation of tooltip overlay

### DIFF
--- a/packages/ui/src/components/Button.tsx
+++ b/packages/ui/src/components/Button.tsx
@@ -19,6 +19,8 @@ import usePrevious from "./hooks/usePrevious";
 import Hoverable from "./Hoverable";
 import Icon from "./Icon";
 import { IconName, IconPosition } from "./IconShared";
+import Tooltip from "./Tooltip";
+
 
 export type ButtonPendingActivationState = "hover" | "pressed" | null;
 
@@ -50,6 +52,7 @@ export type ButtonProps = ButtonContents &
     numberOfLines?: number;
     ellipsizeMode?: TextProps["ellipsizeMode"];
     focusOnMount?: boolean;
+    tooltipText?: string;
   };
 
 const pressedButtonOpacity = 0.2;
@@ -196,7 +199,7 @@ const styles = StyleSheet.create({
 });
 
 export default React.memo(function Button(props: ButtonProps) {
-  const { onPendingInteractionStateDidChange, style } = props;
+  const { onPendingInteractionStateDidChange, style, tooltipText } = props;
   const ref = React.useRef<View | null>(null);
   const href = "href" in props ? props.href : null;
   const onPress = "onPress" in props ? props.onPress : null;
@@ -242,51 +245,59 @@ export default React.memo(function Button(props: ButtonProps) {
       }}
     >
       {(isHovered) => (
-        <Pressable
-          ref={ref}
-          accessible={true}
-          accessibilityRole={href ? "link" : "button"}
-          accessibilityLabel={accessibilityLabel}
-          onPress={
-            onPress
-              ? () => {
-                  isPressed.current = false;
-                  dispatchPendingInteractionState();
-                  onPress();
-                }
-              : () => {
-                  Linking.openURL(href!).catch(() => {
-                    Alert.alert(
-                      "Couldn't open link",
-                      `You may need to install an app to open this URL: ${href}`,
-                    );
-                  });
-                }
-          }
-          onPressIn={() => {
-            isPressed.current = true;
-            dispatchPendingInteractionState();
-          }}
-          onPressOut={() => {
-            isPressed.current = false;
-            dispatchPendingInteractionState();
-          }}
-          // @ts-ignore react-native-web adds this prop
-          delayPressOut={1} // HACK: When a press is completed, we handle onPressOut within onPress so that React batches all updates into a single re-render.
-          disabled={props.disabled}
-          // @ts-ignore react-native-web adds this prop.
-          href={href}
-          hitSlop={props.hitSlop}
-          style={[isSoloIcon && styles.soloIcon, style]}
-        >
-          {({ pressed }) => (
-            <ButtonInterior
-              {...props}
-              isHovered={isHovered}
-              isPressed={pressed}
-            />
-          )}
-        </Pressable>
+          <Pressable
+            ref={ref}
+            accessible={true}
+            accessibilityRole={href ? "link" : "button"}
+            accessibilityLabel={accessibilityLabel}
+            onPress={
+              onPress
+                ? () => {
+                    isPressed.current = false;
+                    dispatchPendingInteractionState();
+                    onPress();
+                  }
+                : () => {
+                    Linking.openURL(href!).catch(() => {
+                      Alert.alert(
+                        "Couldn't open link",
+                        `You may need to install an app to open this URL: ${href}`,
+                      );
+                    });
+                  }
+            }
+            onPressIn={() => {
+              isPressed.current = true;
+              dispatchPendingInteractionState();
+            }}
+            onPressOut={() => {
+              isPressed.current = false;
+              dispatchPendingInteractionState();
+            }}
+            // @ts-ignore react-native-web adds this prop
+            delayPressOut={1} // HACK: When a press is completed, we handle onPressOut within onPress so that React batches all updates into a single re-render.
+            disabled={props.disabled}
+            // @ts-ignore react-native-web adds this prop.
+            href={href}
+            hitSlop={props.hitSlop}
+            style={[isSoloIcon && styles.soloIcon, style]}
+          >
+            {({ pressed }) => (
+              <React.Fragment>
+                {tooltipText && (<Tooltip
+                  anchorRef={ref}
+                  show={isHovered}
+                  text={tooltipText}
+                  placement="inset-bottom-right"
+                />)}
+                <ButtonInterior
+                  {...props}
+                  isHovered={isHovered}
+                  isPressed={pressed}
+                />
+              </React.Fragment>
+            )}
+          </Pressable>
       )}
     </Hoverable>
   );

--- a/packages/ui/src/components/ReviewButtonBar.tsx
+++ b/packages/ui/src/components/ReviewButtonBar.tsx
@@ -168,6 +168,7 @@ const ReviewButtonBar = React.memo(function ReviewButtonArea({
               dispatchPendingMarkingInteraction();
             }}
             hitSlop={firstButtonSlop}
+            tooltipText={"Shortcut: 1"}
           />
           {spacer}
           <Button
@@ -186,6 +187,7 @@ const ReviewButtonBar = React.memo(function ReviewButtonArea({
               dispatchPendingMarkingInteraction();
             }}
             hitSlop={secondButtonSlop}
+            tooltipText={"Shortcut: Space or 2"}
           />
         </>
       );
@@ -199,6 +201,7 @@ const ReviewButtonBar = React.memo(function ReviewButtonArea({
             title={"Show answer"}
             key={"Show answer"}
             hitSlop={secondButtonSlop}
+            tooltipText={"Shortcut: Space"}
           />
         </>
       );

--- a/packages/ui/src/components/Tooltip.stories.tsx
+++ b/packages/ui/src/components/Tooltip.stories.tsx
@@ -1,0 +1,93 @@
+import { boolean, number, text, select, withKnobs } from "@storybook/addon-knobs";
+
+import React, { useState, useRef } from "react";
+import Hoverable from "./Hoverable";
+import Tooltip from "./Tooltip";
+import { Pressable, View } from "react-native";
+import { MutableRefObject } from "react";
+
+export default {
+  title: "Tooltip",
+  component: Tooltip,
+  decorators: [withKnobs]
+};
+
+export function Text() {
+  const [isHovered, setHovered] = useState(false);
+  const ref = useRef<View | null>(null);
+  return (
+    <Hoverable
+      onHoverIn={() => setHovered(true)}
+      onHoverOut={() => setHovered(false)}
+    >
+      <View
+        ref={ref}
+        style={{ border: "1px solid black", width: "200px", height: "100px", padding: 20, margin: 100 }}
+      >
+        <Tooltip 
+          show={isHovered}
+          placement={select("direction", ["top", "right", "bottom", "left", "overlay", "inset-bottom-left", "inset-bottom-right", "inset-top-left", "inset-top-right", "cursor"], "top")}
+          text="Tooltip text"
+          anchorRef={ref}
+        />
+        <div>Some Text That Is Important</div>
+      </View>
+    </Hoverable>
+  );
+}
+
+export function Children() {
+  const [isHovered, setHovered] = useState(false);
+  const ref = useRef<View | null>(null);
+  return (
+    <Hoverable
+      onHoverIn={() => setHovered(true)}
+      onHoverOut={() => setHovered(false)}
+    >
+      <View
+        ref={ref}
+        style={{ border: "1px solid black", width: "200px", height: "100px", padding: 20, margin: 100 }}
+      >
+        <Tooltip 
+          show={isHovered}
+          placement={select("placement", ["top", "right", "bottom", "left", "overlay", "inset-bottom-left", "inset-bottom-right", "inset-top-left", "inset-top-right", "cursor"], "top")}
+          text="Tooltip text"
+          anchorRef={ref}
+        >
+          <View style={{ flexDirection: "row", width: "100%", height: "100%", alignItems: "center", justifyContent: "space-around" }}>
+            <View style={{ border: "1px solid red", backgroundColor: "red" }}>
+              <p>L</p>
+            </View>
+            <View style={{ border: "1px solid blue", backgroundColor: "blue" }}>
+              <p>R</p>
+            </View>
+          </View>
+        </Tooltip>
+        <div>Some Text That Is Important</div>
+      </View>
+    </Hoverable>
+  );
+}
+
+export function Button() {
+  const [isHovered, setHovered] = useState(false);
+  const ref = useRef<View | null>(null);
+  return (
+    <Hoverable
+      onHoverIn={() => setHovered(true)}
+      onHoverOut={() => setHovered(false)}
+    >
+      <Pressable
+        style={{ border: "1px solid black", width: "120px", height: "50px", margin: 150 }}
+        ref={ref}>
+        <p>A Pressable</p>
+        <Tooltip 
+          show={isHovered}
+          placement={select("placement", ["top", "right", "bottom", "left", "overlay", "inset-bottom-left", "inset-bottom-right", "inset-top-left", "inset-top-right", "cursor"], "top")}
+          text="Tooltip text"
+          anchorRef={ref}
+        />
+      </Pressable>
+    </Hoverable>
+  );
+}

--- a/packages/ui/src/components/Tooltip.tsx
+++ b/packages/ui/src/components/Tooltip.tsx
@@ -1,0 +1,275 @@
+import React, { useRef, useState, useReducer, useCallback, useMemo } from "react";
+import { useEffect } from "react";
+import {
+  ColorValue,
+  StyleProp,
+  StyleSheet,
+  View,
+  ViewStyle,
+} from "react-native";
+
+
+const styles = StyleSheet.create({
+  triangle: {
+    position: 'absolute',
+    width: 0,
+    height: 0,
+    backgroundColor: 'transparent',
+    borderStyle: 'solid',
+    borderLeftWidth: 8,
+    borderRightWidth: 8,
+    borderBottomWidth: 16,
+    borderLeftColor: 'transparent',
+    borderRightColor: 'transparent',
+    borderBottomColor: 'white',
+  },
+  container: {
+    position: "absolute",
+    width: "100%",
+    height: "100%",
+    left: 0,
+    top: 0
+  },
+  tooltip: {
+    padding: "10px",
+    backgroundColor: "black",
+    opacity: 0.5,
+    zIndex: 10000,
+  }
+});
+
+type TriangleProps = {
+  pointerColor?: ColorValue;
+  style?: StyleProp<ViewStyle>;
+  placement: TooltipPosition;
+  trianglePosition: { top?: number, left?: number };
+};
+
+const TRIANGLE_ROTATION: { [key: string]: number } = {
+  "bottom": 0,
+  "left": 90,
+  "top": 180,
+  "right": 270
+}
+
+const Triangle: React.FC<TriangleProps> = ({ style, pointerColor, placement, trianglePosition }) => (
+  <View
+    style={StyleSheet.flatten([
+      styles.triangle,
+      {
+        borderBottomColor: pointerColor,
+        transform: [{ rotate: `${TRIANGLE_ROTATION[placement]}deg`}],
+        ...trianglePosition,
+      },
+      style,
+    ])}
+  />
+);
+
+export type TooltipPosition = "top"
+  | "right"
+  | "bottom"
+  | "left"
+  | "overlay"
+  | "inset-bottom-left"
+  | "inset-bottom-right"
+  | "inset-top-left"
+  | "inset-top-right"
+  | "cursor" 
+
+export type TooltipProps = {
+  placement?: TooltipPosition;
+  stayOnScreen?: boolean;
+  show: boolean;
+  anchorRef: React.MutableRefObject<View | null>;
+} & ({ text: string; } | { children: React.ReactNode; })
+
+const getPositions = (
+  { placement, anchor, tooltip }: { placement: string, anchor: Measure, tooltip: Measure }
+): TooltipState => {
+  switch (placement) {
+    case "top":
+      return {
+        tooltipPosition: { top: -tooltip.height - 16, left: anchor.width/2 - tooltip.width/2 },
+        trianglePosition: { top: tooltip.height - 1, left: tooltip.width/2 - 7.5 }
+      }
+    case "right":
+      return {
+        tooltipPosition: { top: anchor.height/2 - tooltip.height/2, left: anchor.width + 15 },
+        trianglePosition: { top: tooltip.height/2 - 7.5, left: -15 }
+      }
+    case "bottom":
+      return {
+        tooltipPosition: { top: anchor.height + 15, left: anchor.width/2 - tooltip.width/2 },
+        trianglePosition: { top: -15, left: tooltip.width/2 - 7.5 }
+      }
+    case "left":
+      return {
+        tooltipPosition: { top: anchor.height/2 - tooltip.height/2, left: -tooltip.width - 16 },
+        trianglePosition: { top: tooltip.height/2 - 7.5, left: tooltip.width - 1 }
+      }
+    case "overlay":
+      return {
+        tooltipPosition: { top: 0, left: 0, width: anchor.width, height: anchor.height },
+        trianglePosition: {}
+      }
+    case "inset-bottom-left":
+      return {
+        tooltipPosition: { bottom: 0, left: 0 },
+        trianglePosition: {}
+      }
+    case "inset-top-left":
+      return {
+        tooltipPosition: { top: 0, left: 0 },
+        trianglePosition: {}
+      }
+    case "inset-top-right":
+      return {
+        tooltipPosition: { top: 0, right: 0 },
+        trianglePosition: {}
+      }
+    case "inset-bottom-right":
+      return {
+        tooltipPosition: { bottom: 0, right: 0 },
+        trianglePosition: {}
+      }
+    default:
+      return { tooltipPosition: {}, trianglePosition: {} }
+  }
+}
+
+type UIPosition = { top?: number, bottom?: number, left?: number, right?: number, width?: number, height?: number }
+
+type TooltipState = {
+  tooltipPosition?: UIPosition,
+  trianglePosition?: UIPosition,
+}
+
+type Measure = { width?: number, height?: number, x?: number, y?: number, pageX?: number, pageY?: number, }
+
+export default (props: TooltipProps) => {
+  const {
+    placement = "top",
+    show,
+    anchorRef,
+    text,
+    children,
+  } = props;
+
+  const tooltipRef = useRef<View | null>(null)
+  const containerRef = useRef<View | null>(null)
+
+  const [{ tooltipPosition, trianglePosition }, dispatch] = useReducer((
+    state: TooltipState,
+    { type, payload }: { type: string, payload: any }
+  ) => {
+    if (type === "init") {
+      return { ...getPositions(payload) }
+    }
+    if (type === "move") {
+      return {
+        tooltipPosition: { ...payload }
+      }
+    }
+    return state
+  }, {})
+
+  const [containerMeasure, setContainerMeasure] = useState<Measure>({})
+  useEffect(() => {
+    if (containerRef.current) {
+      containerRef.current.measure((x, y, width, height, pageX, pageY) => {
+        setContainerMeasure({
+          pageX,
+          pageY,
+        })
+      })
+    }
+  }, [containerRef])
+
+  const [anchorMeasure, setAnchorMeasure] = useState<Measure>({})
+  useEffect(() => {
+    if (anchorRef.current) {
+      anchorRef.current.measure((x, y, width, height) => {
+        setAnchorMeasure({
+          width,
+          height,
+        })
+      })
+    }
+  }, [anchorRef])
+  
+  useEffect(() => {
+    if (anchorMeasure.width && tooltipRef.current) {
+      tooltipRef.current.measure((x, y, width, height) => {
+        dispatch({
+          type: "init",
+          payload: {
+            placement,
+            anchor: anchorMeasure,
+            tooltip: { width, height }
+          }
+        })
+      })
+    }
+  }, [
+    anchorMeasure,
+    tooltipRef.current,
+    show,
+    placement
+  ])
+
+  const trackCursor = useCallback(
+    (e: React.MouseEvent) => {
+      if (!containerMeasure) return
+      dispatch({
+        type: "move",
+        payload: {
+          top: e.clientY - containerMeasure.pageY,
+          left: e.clientX - containerMeasure.pageX,
+        }
+      })
+    },
+    [containerMeasure]
+  )
+
+  const mouseEvents = useMemo(() => placement === "cursor" ? {
+    onMouseMove: trackCursor,
+  } : {}, [placement, trackCursor])
+
+  // TODO: a "stay-on-screen" effect
+  // TODO: potentially use composition instead of anchorRef
+  // =====] how do you do this without affecting the child's original context?
+  // =====] e.g. for current Hoverable/Button implementation we require Pressable to receive mouse events
+
+  // embedded views to pick up the "cursor" event
+  return (
+    <View
+      ref={containerRef}
+      style={styles.container}
+      {...mouseEvents}
+    >
+      <View
+        ref={tooltipRef}
+        style={StyleSheet.flatten([
+          (
+            !show || (placement === "cursor" && !tooltipPosition.left)
+          ) && { visibility: "hidden" },
+          {
+            position: (placement.indexOf("inset") === 0 || placement === "cursor") ? "absolute" : "relative",
+            width: placement === "overlay" ? "100%" : "fit-content",
+            height: placement === "overlay" ? "100%" : "fit-content",
+            ...tooltipPosition
+          },
+          styles.tooltip,
+        ])}
+      >
+        {["top", "right", "bottom", "left"].includes(placement) && <Triangle placement={placement} trianglePosition={trianglePosition} />}
+        {children || (
+          <div style={{ color: "white" }}>
+            {text}
+          </div>
+        )}
+      </View>
+    </View>
+  );
+};

--- a/packages/ui/src/components/__fixtures__/generateReviewItem.ts
+++ b/packages/ui/src/components/__fixtures__/generateReviewItem.ts
@@ -24,6 +24,17 @@ export function generateReviewItem(
     componentID: mainTaskComponentID,
     spec: {
       ...testQASpec,
+      content: {
+        ...testQASpec.content,
+        body: {
+          ...testQASpec.content.body,
+          text: questionText,
+        },
+        answer: {
+          ...testQASpec.content.answer,
+          text: answerText,
+        }
+      }
     },
   };
 }


### PR DESCRIPTION
I did a basic implementation for #224 and tried to keep it flexible, since there hadn't been a design discussion yet. I tried to look at some existing packages, but they didn't seem compatible with the Hoverable implementation.

I'm pretty new to typescript, react native and this project, so I'd be happy to refactor to conform to any standards that I missed.

![Screen Shot 2021-11-08 at 5 26 31 PM](https://user-images.githubusercontent.com/17012062/140828629-2d96a3d8-0f58-4fc8-a119-814d4d3602f5.png)
![Screen Shot 2021-11-08 at 5 27 02 PM](https://user-images.githubusercontent.com/17012062/140828656-767ee04f-d8d6-45b0-8864-0145b5ca5847.png)
![Screen Shot 2021-11-08 at 5 26 55 PM](https://user-images.githubusercontent.com/17012062/140828664-d4627466-603b-47c6-803e-3c6e3187314e.png)
![Screen Shot 2021-11-08 at 5 26 45 PM](https://user-images.githubusercontent.com/17012062/140828669-fc965bfc-1432-4cd0-8d9f-7eedc4dcc704.png)

Immediate TODOs or improvements would be:
- [] more configurable style related props (e.g. color of background & text)
- [] stay on screen
- [] switch the usage from supplying a `ref` of the desired component to composition with built-in hover/touch/arbitrary trigger


