### PR TITLE
Add support for key commands in mac/iOS

### DIFF
--- a/packages/app/ios/Orbit/AppDelegate.m
+++ b/packages/app/ios/Orbit/AppDelegate.m
@@ -15,6 +15,8 @@
 
 #import "ORDebugManager.h"
 
+#import <RNKeyEvent.h>
+
 #if 0
 //#if DEBUG && !TARGET_OS_MACCATALYST
 #import <FlipperKit/FlipperClient.h>
@@ -219,6 +221,42 @@ static void InitializeFlipper(UIApplication *application) {
 - (void)signOut {
   [[FIRAuth auth] signOut:nil];
   [self clearCaches];
+}
+
+RNKeyEvent *keyEvent = nil;
+
+- (NSMutableArray<UIKeyCommand *> *)keyCommands {
+  NSMutableArray *keys = [NSMutableArray new];
+  
+  if (keyEvent == nil) {
+    keyEvent = [[RNKeyEvent alloc] init];
+  }
+  
+  if ([keyEvent isListening]) {
+    // need to add space as a valid character, otherwise it is ignored
+    NSArray *extraNames = [NSArray arrayWithObjects: @" ",nil];
+    NSArray *defaultNamesArray = [[keyEvent getKeys] componentsSeparatedByString:@","];
+    NSArray *namesArray = [defaultNamesArray arrayByAddingObjectsFromArray:extraNames];
+    
+    NSCharacterSet *validChars = [NSCharacterSet characterSetWithCharactersInString:@"ABCDEFGHIJKLMNOPQRSTUVWXYZ"];
+    
+    for (NSString* names in namesArray) {
+      NSRange  range = [names rangeOfCharacterFromSet:validChars];
+      
+      if (NSNotFound != range.location) {
+        [keys addObject: [UIKeyCommand keyCommandWithInput:names modifierFlags:UIKeyModifierShift action:@selector(keyInput:)]];
+      } else {
+        [keys addObject: [UIKeyCommand keyCommandWithInput:names modifierFlags:0 action:@selector(keyInput:)]];
+      }
+    }
+  }
+  
+  return keys;
+}
+
+- (void)keyInput:(UIKeyCommand *)sender {
+  NSString *selected = sender.input;
+  [keyEvent sendKeyEvent:selected];
 }
 
 @end

--- a/packages/app/ios/Podfile.lock
+++ b/packages/app/ios/Podfile.lock
@@ -272,6 +272,8 @@ PODS:
   - React-jsinspector (0.63.4)
   - react-native-get-random-values (1.7.0):
     - React-Core
+  - react-native-keyevent (0.2.8):
+    - React
   - react-native-quick-sqlite (1.0.5):
     - React-Core
   - react-native-safe-area-context (3.2.0):
@@ -393,6 +395,7 @@ DEPENDENCIES:
   - React-jsiexecutor (from `../../../node_modules/react-native/ReactCommon/jsiexecutor`)
   - React-jsinspector (from `../../../node_modules/react-native/ReactCommon/jsinspector`)
   - react-native-get-random-values (from `../../../node_modules/react-native-get-random-values`)
+  - react-native-keyevent (from `../../../node_modules/react-native-keyevent`)
   - react-native-quick-sqlite (from `../../../node_modules/react-native-quick-sqlite`)
   - react-native-safe-area-context (from `../../../node_modules/react-native-safe-area-context`)
   - React-RCTActionSheet (from `../../../node_modules/react-native/Libraries/ActionSheetIOS`)
@@ -488,6 +491,8 @@ EXTERNAL SOURCES:
     :path: "../../../node_modules/react-native/ReactCommon/jsinspector"
   react-native-get-random-values:
     :path: "../../../node_modules/react-native-get-random-values"
+  react-native-keyevent:
+    :path: "../../../node_modules/react-native-keyevent"
   react-native-quick-sqlite:
     :path: "../../../node_modules/react-native-quick-sqlite"
   react-native-safe-area-context:
@@ -571,6 +576,7 @@ SPEC CHECKSUMS:
   React-jsiexecutor: 93bd528844ad21dc07aab1c67cb10abae6df6949
   React-jsinspector: 58aef7155bc9a9683f5b60b35eccea8722a4f53a
   react-native-get-random-values: 237bffb1c7e05fb142092681531810a29ba53015
+  react-native-keyevent: f8728b8c73dbfbcb4d2c56d9e78be082c673c456
   react-native-quick-sqlite: b86820d88ce8c0ee4b5491a2ba1ebbf807a311b4
   react-native-safe-area-context: f0906bf8bc9835ac9a9d3f97e8bde2a997d8da79
   React-RCTActionSheet: 89a0ca9f4a06c1f93c26067af074ccdce0f40336

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -64,6 +64,7 @@
     "react-dom": "17.0.1",
     "react-native": "0.63.4",
     "react-native-get-random-values": "~1.7.0",
+    "react-native-keyevent": "^0.2.8",
     "react-native-quick-sqlite": "^1.0.5",
     "react-native-safe-area-context": "3.2.0",
     "react-native-svg": "12.1.1",

--- a/packages/ui/src/components/hooks/useKey.ts
+++ b/packages/ui/src/components/hooks/useKey.ts
@@ -21,7 +21,8 @@ export function useKeyDown(onKeyDown: (event: KeydownEvent) => void) {
 
   useEffect(() => {
     if (!(Platform.OS === "macos" || Platform.OS === "ios")) return;
-
+    // [27/01/21] onKeyDownListener is unimplemented for iOS. Will use onKeyUp listener for now.
+    //  Related Issue: https://github.com/kevinejohn/react-native-keyevent/issues/62
     KeyEvent.onKeyUpListener((e: unknown) => {
       if (typeof e !== "object" || !e) return;
 

--- a/packages/ui/src/components/hooks/useKey.ts
+++ b/packages/ui/src/components/hooks/useKey.ts
@@ -1,14 +1,37 @@
 import React, { useEffect } from "react";
+import KeyEvent from "react-native-keyevent";
 import { Platform } from "react-native";
 
-export type KeyboardEvent = React.KeyboardEvent;
+type KeydownEvent = {
+  key: string;
+  repeat: boolean;
+};
 
-export function useKeyDown(onKeyDown: (event: KeyboardEvent) => void) {
+export function useKeyDown(onKeyDown: (event: KeydownEvent) => void) {
   useEffect(() => {
     if (Platform.OS !== "web") return;
 
-    document.addEventListener("keydown", onKeyDown);
+    const listener = (e: React.KeyboardEvent) => {
+      onKeyDown(e);
+    };
 
-    return () => document.removeEventListener("keydown", onKeyDown);
+    document.addEventListener("keydown", listener);
+    return () => document.removeEventListener("keydown", listener);
+  }, [onKeyDown]);
+
+  useEffect(() => {
+    if (!(Platform.OS === "macos" || Platform.OS === "ios")) return;
+
+    KeyEvent.onKeyUpListener((e: unknown) => {
+      if (typeof e !== "object" || !e) return;
+
+      if ("pressedKey" in e) {
+        const event = e as { pressedKey: string };
+        // the react-native-keyevent library does not provide the
+        // repeat key, so we'll just assume it is
+        onKeyDown({ key: event.pressedKey, repeat: false });
+      }
+    });
+    return () => KeyEvent.removeKeyUpListener();
   }, [onKeyDown]);
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -24144,6 +24144,11 @@ react-native-get-random-values@~1.7.0:
   dependencies:
     fast-base64-decode "^1.0.0"
 
+react-native-keyevent@^0.2.8:
+  version "0.2.8"
+  resolved "https://registry.yarnpkg.com/react-native-keyevent/-/react-native-keyevent-0.2.8.tgz#f6c035bf17b8d8221e546e85e430cd1d3021c5d7"
+  integrity sha512-tqZwJXDpAL7rBUGRAz4AaoAyQkaWA7k1Bq+l7P4GLsWAD7g0z/KSAOMY3cJanLYJxr4+t4FEZ8seA1YQ/7kchg==
+
 react-native-markdown-display@^6.1.6:
   version "6.1.6"
   resolved "https://registry.yarnpkg.com/react-native-markdown-display/-/react-native-markdown-display-6.1.6.tgz#74cbc9e1e2b2169a7ca8d959883e18790ea2b2aa"


### PR DESCRIPTION
Related https://github.com/andymatuschak/orbit/issues/223

## What?
Add support for key commands in macOS and iOS. 

## How?
I ended up integrating the iOS portion of [react-native-keyevent](https://github.com/kevinejohn/react-native-keyevent) since I couldn't find an acceptable solution using React Native API's (e.g view does not seem to support `onkeyevent`, only `TextInput` has access to key based callbacks AFAIK). I also only did the setup for iOS since I don't have any means to test the android platforms and I wasn't sure if there would be any utility there at this point anyways.

## How did I test this?
- Ran the macOS/Catalyst app pointed to dev
- Ran the macOS/Catalyst app pointed to prod and did my morning review using the key commands
- Ran the iPad app in the simulator
- Ran the web app pointed to dev to ensure no regressions