### PR TITLE
Intermediate format to simplify syncing

### DIFF
--- a/.github/workflows/ts.yml
+++ b/.github/workflows/ts.yml
@@ -65,5 +65,9 @@ jobs:
       - name: "run generateSchema for the events validator"
         working-directory: packages/store-shared
         run: "yarn generateSchema"
+      - name: "run generateSchema for the ingester validator"
+        working-directory: packages/ingester
+        run: "yarn generateSchema"
       - name: "check if changes are pending"
         run: "git diff --exit-code"
+        working-directory: packages

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "scripts": {
     "build": "tsc -b packages/tsconfig.json && (cd packages/backend; yarn build)",
     "watch": "tsc -b -w packages/tsconfig.json",
-    "test": "cd packages; npx jest --projects anki-import api-client backend core web-component note-sync api store-fs store-web --runInBand",
+    "test": "cd packages; npx jest --projects anki-import api-client ingester backend core web-component note-sync api store-fs store-web --runInBand",
     "test:watch": "yarn run test --watch",
     "lint": "cd packages; eslint .",
     "lint:fix": "cd packages; eslint --fix .",

--- a/packages/ingester/LICENSE
+++ b/packages/ingester/LICENSE
@@ -1,0 +1,175 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.

--- a/packages/ingester/babel.config.cjs
+++ b/packages/ingester/babel.config.cjs
@@ -1,0 +1,13 @@
+module.exports = {
+  presets: [
+    [
+      "@babel/preset-env",
+      {
+        targets: {
+          node: "current",
+        },
+      },
+    ],
+    "@babel/preset-typescript",
+  ],
+};

--- a/packages/ingester/jest.config.cjs
+++ b/packages/ingester/jest.config.cjs
@@ -1,0 +1,5 @@
+module.exports = {
+  testEnvironment: "node",
+  testMatch: ["**/?(*.)+(spec|test).ts?(x)"],
+  testPathIgnorePatterns: ["dist", "node_modules"],
+};

--- a/packages/ingester/package.json
+++ b/packages/ingester/package.json
@@ -10,7 +10,7 @@
     "build": "tsc -b",
     "test": "jest --runInBand",
     "ingest": "yarn build; node --experimental-specifier-resolution=node dist/bin/run.js",
-    "generateSchema": "typescript-json-schema src/orbitAPI.ts ValidatableSpec -o src/orbitAPISchema.json --noExtraProps --required --ignoreErrors --strictNullChecks"
+    "generateSchema": "typescript-json-schema src/ingestible.ts Ingestible -o src/ingestible.json --noExtraProps --required --ignoreErrors --strictNullChecks"
   },
   "dependencies": {
     "@withorbit/core": "0.0.1",

--- a/packages/ingester/package.json
+++ b/packages/ingester/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "@withorbit/ingester",
+  "version": "0.0.1",
+  "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "private": true,
+  "sideEffects": false,
+  "scripts": {
+    "build": "tsc -b",
+    "test": "jest --runInBand",
+    "ingest": "yarn build; node --experimental-specifier-resolution=node dist/bin/run.js",
+    "generateSchema": "typescript-json-schema src/orbitAPI.ts ValidatableSpec -o src/orbitAPISchema.json --noExtraProps --required --ignoreErrors --strictNullChecks"
+  },
+  "dependencies": {
+    "@withorbit/core": "0.0.1",
+    "@withorbit/store-shared": "0.0.1",
+    "@withorbit/store-fs": "0.0.1",
+    "ajv": "^8.6.2"
+  },
+  "devDependencies": {
+    "@types/jest": "^26.0.24",
+    "@types/node": "^14.14.7",
+    "babel-jest": "^27.0.6",
+    "jest": "^27.0.6",
+    "typescript": "^4.2.4",
+    "typescript-json-schema": "^0.50.0"
+  }
+}

--- a/packages/ingester/package.json
+++ b/packages/ingester/package.json
@@ -14,8 +14,8 @@
   },
   "dependencies": {
     "@withorbit/core": "0.0.1",
-    "@withorbit/store-shared": "0.0.1",
     "@withorbit/store-fs": "0.0.1",
+    "@withorbit/store-shared": "0.0.1",
     "ajv": "^8.6.2"
   },
   "devDependencies": {

--- a/packages/ingester/src/bin/run.ts
+++ b/packages/ingester/src/bin/run.ts
@@ -1,0 +1,20 @@
+import OrbitStoreFS from "@withorbit/store-fs";
+import { ingestSources } from "../ingest";
+
+(async () => {
+  const orbitStorePath = process.argv[2];
+  // const noteDirectory = process.argv[3];
+  if (!orbitStorePath) {
+    console.error("yarn ingest /path/to/orbit-store");
+    process.exit(0);
+  }
+
+  // TODO: temporary, move this CLI to a new package
+  const orbitStore = new OrbitStoreFS(orbitStorePath);
+  await ingestSources([], orbitStore);
+})()
+  .then(() => {
+    console.log("Done");
+    process.exit(0);
+  })
+  .catch(console.error);

--- a/packages/ingester/src/bin/run.ts
+++ b/packages/ingester/src/bin/run.ts
@@ -9,7 +9,6 @@ import { ingestSources } from "../ingest";
     process.exit(0);
   }
 
-  // TODO: temporary, move this CLI to a new package
   const orbitStore = new OrbitStoreFS(orbitStorePath);
   await ingestSources([], orbitStore);
 })()

--- a/packages/ingester/src/bin/run.ts
+++ b/packages/ingester/src/bin/run.ts
@@ -1,19 +1,56 @@
 import OrbitStoreFS from "@withorbit/store-fs";
+import fs from "fs";
 import { ingestSources } from "../ingest";
+import { Ingestible } from "../ingestible";
+import { createIngestibleValidator } from "../validateIngestible";
+
+async function run(config: { ingestible: Ingestible; orbitStorePath: string }) {
+  const orbitStore = new OrbitStoreFS(config.orbitStorePath);
+  try {
+    const events = await ingestSources(config.ingestible.sources, orbitStore);
+    console.log(events);
+    await orbitStore.database.putEvents(events);
+  } catch (error) {
+    orbitStore.close();
+    throw error;
+  }
+}
+
+const validator = createIngestibleValidator({ mutateWithDefaultValues: true });
 
 (async () => {
+  // ensure that the arguments are defined
   const orbitStorePath = process.argv[2];
-  // const noteDirectory = process.argv[3];
-  if (!orbitStorePath) {
-    console.error("yarn ingest /path/to/orbit-store");
-    process.exit(0);
+  const jsonFilePath = process.argv[3];
+  if (!orbitStorePath || !jsonFilePath) {
+    console.error("Usage: yarn ingest /path/to/orbit-store /path/to/json-file");
+    process.exit(1);
   }
 
-  const orbitStore = new OrbitStoreFS(orbitStorePath);
-  await ingestSources([], orbitStore);
+  // validate that the JSON file exists and is valid
+  let ingestibleJson: unknown;
+  try {
+    if (fs.existsSync(jsonFilePath)) {
+      ingestibleJson = JSON.parse(fs.readFileSync(jsonFilePath, "utf8"));
+    } else {
+      console.error(`File does not exist at path: ${jsonFilePath}`);
+      process.exit(1);
+    }
+  } catch (err) {
+    console.error(err);
+    process.exit(1);
+  }
+  const { isValid, errors } = validator.validate(ingestibleJson);
+  if (!isValid) {
+    console.error(`Cannot ingest file at ${jsonFilePath}`);
+    console.error(errors);
+    process.exit(1);
+  }
+  // begin ingestion
+  const ingestible = ingestibleJson as Ingestible;
+  await run({ ingestible, orbitStorePath });
 })()
   .then(() => {
-    console.log("Done");
     process.exit(0);
   })
   .catch(console.error);

--- a/packages/ingester/src/index.ts
+++ b/packages/ingester/src/index.ts
@@ -1,0 +1,2 @@
+export * from "./ingestible";
+export * from "./ingest";

--- a/packages/ingester/src/ingest.test.ts
+++ b/packages/ingester/src/ingest.test.ts
@@ -1,0 +1,200 @@
+import {
+  EventID,
+  EventType,
+  TaskContentType,
+  TaskID,
+  TaskIngestEvent,
+  TaskSpecType,
+  TaskUpdateDeletedEvent,
+} from "@withorbit/core";
+import { OrbitStoreInMemory } from "@withorbit/store-fs";
+import { ingestSources } from "./ingest";
+import {
+  IngestibleSource,
+  IngestibleSourceIdentifier,
+} from "./ingestibleSource";
+
+it("ingest new prompts from unknown source", async () => {
+  const store = new OrbitStoreInMemory();
+  const sources: IngestibleSource[] = [
+    {
+      identifier: "source_identifier" as IngestibleSourceIdentifier,
+      title: "Brand new source",
+      prompts: [
+        { type: "qa", body: { text: "Question" }, answer: { text: "Answer" } },
+      ],
+    },
+  ];
+
+  const events = await ingestSources(sources, store);
+  expect(events).toHaveLength(1);
+  expect(events[0].type).toBe(EventType.TaskIngest);
+  const event = events[0] as TaskIngestEvent;
+
+  expect(event.provenance).toEqual({
+    identifier: "source_identifier",
+    title: "Brand new source",
+  });
+  expect(event.spec).toEqual({
+    type: "memory",
+    content: {
+      type: "qa",
+      body: { text: "Question", attachments: [] },
+      answer: { text: "Answer", attachments: [] },
+    },
+  });
+});
+
+it("ingest new prompts from known source", async () => {
+  const store = new OrbitStoreInMemory();
+  await store.database.putEvents([
+    mockQATask({
+      eventID: "aaaaaaaaaaaaaaaaaaaaaa",
+      entityID: "xxxxxxxxxxxxxxxxxxxxxx",
+      body: "Question",
+      answer: "Answer",
+      provenance: { identifier: "source_identifier", title: "Existing Source" },
+    }),
+  ]);
+  const sources: IngestibleSource[] = [
+    {
+      identifier: "source_identifier" as IngestibleSourceIdentifier,
+      title: "Existing Source",
+      prompts: [
+        {
+          type: "qa",
+          body: { text: "Question" },
+          answer: { text: "Answer" },
+        },
+        {
+          type: "qa",
+          body: { text: "New Question" },
+          answer: { text: "New Answer" },
+        },
+      ],
+    },
+  ];
+
+  const events = await ingestSources(sources, store);
+  expect(events).toHaveLength(1);
+  expect(events[0].type).toBe(EventType.TaskIngest);
+  const event = events[0] as TaskIngestEvent;
+
+  expect(event.provenance).toEqual({
+    identifier: "source_identifier",
+    title: "Existing Source",
+  });
+  expect(event.spec).toEqual({
+    type: "memory",
+    content: {
+      type: "qa",
+      body: { text: "New Question", attachments: [] },
+      answer: { text: "New Answer", attachments: [] },
+    },
+  });
+});
+
+it("ignores already ingested prompts", async () => {
+  const store = new OrbitStoreInMemory();
+  await store.database.putEvents([
+    mockQATask({
+      eventID: "aaaaaaaaaaaaaaaaaaaaaa",
+      entityID: "xxxxxxxxxxxxxxxxxxxxxx",
+      body: "Question",
+      answer: "Answer",
+      provenance: { identifier: "source_identifier", title: "Existing Source" },
+    }),
+  ]);
+
+  const sources: IngestibleSource[] = [
+    {
+      identifier: "source_identifier" as IngestibleSourceIdentifier,
+      title: "Existing Source",
+      prompts: [
+        {
+          type: "qa",
+          body: { text: "Question" },
+          answer: { text: "Answer" },
+        },
+      ],
+    },
+  ];
+
+  const events = await ingestSources(sources, store);
+  expect(events).toHaveLength(0);
+});
+
+it("marks prompts as deleted", async () => {
+  const store = new OrbitStoreInMemory();
+  await store.database.putEvents([
+    mockQATask({
+      eventID: "aaaaaaaaaaaaaaaaaaaaaa",
+      entityID: "xxxxxxxxxxxxxxxxxxxxxx",
+      body: "Question",
+      answer: "Answer",
+      provenance: { identifier: "source_identifier", title: "Existing Source" },
+    }),
+  ]);
+
+  const sources: IngestibleSource[] = [
+    {
+      identifier: "source_identifier" as IngestibleSourceIdentifier,
+      title: "Existing Source",
+      prompts: [],
+    },
+  ];
+
+  const events = await ingestSources(sources, store);
+  expect(events).toHaveLength(1);
+  expect(events[0].type).toBe(EventType.TaskUpdateDeleted);
+  const event = events[0] as TaskUpdateDeletedEvent;
+
+  expect(event.entityID).toEqual("xxxxxxxxxxxxxxxxxxxxxx");
+  expect(event.isDeleted).toBeTruthy();
+});
+
+it("only ingests specified sources", async () => {
+  const store = new OrbitStoreInMemory();
+  await store.database.putEvents([
+    mockQATask({
+      eventID: "aaaaaaaaaaaaaaaaaaaaaa",
+      entityID: "xxxxxxxxxxxxxxxxxxxxxx",
+      body: "Question",
+      answer: "Answer",
+      provenance: { identifier: "source_identifier", title: "Existing Source" },
+    }),
+  ]);
+  // the existing source is not specified in the ingestible sources array, but
+  // exists in the DB
+  const sources: IngestibleSource[] = [];
+
+  const events = await ingestSources(sources, store);
+  expect(events).toHaveLength(0);
+});
+
+function mockQATask(args: {
+  eventID: string;
+  entityID: string;
+  body: string;
+  answer: string;
+  provenance: { identifier: string; title: string };
+}): TaskIngestEvent {
+  return {
+    id: args.eventID as EventID,
+    type: EventType.TaskIngest,
+    timestampMillis: 0,
+    entityID: args.entityID as TaskID,
+    spec: {
+      type: TaskSpecType.Memory,
+      content: {
+        type: TaskContentType.QA,
+        body: { text: args.body, attachments: [] },
+        answer: { text: args.answer, attachments: [] },
+      },
+    },
+    provenance: {
+      identifier: args.provenance.identifier,
+      title: args.provenance.title,
+    },
+  };
+}

--- a/packages/ingester/src/ingest.test.ts
+++ b/packages/ingester/src/ingest.test.ts
@@ -9,13 +9,18 @@ import {
 } from "@withorbit/core";
 import { OrbitStoreInMemory } from "@withorbit/store-fs";
 import { ingestSources } from "./ingest";
-import {
-  IngestibleSource,
-  IngestibleSourceIdentifier,
-} from "./ingestibleSource";
+import { IngestibleSource, IngestibleSourceIdentifier } from "./ingestible";
+
+let store: OrbitStoreInMemory;
+beforeEach(() => {
+  store = new OrbitStoreInMemory();
+});
+
+afterEach(() => {
+  store.database.close();
+});
 
 it("ingest new prompts from unknown source", async () => {
-  const store = new OrbitStoreInMemory();
   const sources: IngestibleSource[] = [
     {
       identifier: "source_identifier" as IngestibleSourceIdentifier,
@@ -46,7 +51,6 @@ it("ingest new prompts from unknown source", async () => {
 });
 
 it("ingest new prompts from known source", async () => {
-  const store = new OrbitStoreInMemory();
   await store.database.putEvents([
     mockQATask({
       eventID: "aaaaaaaaaaaaaaaaaaaaaa",
@@ -95,7 +99,6 @@ it("ingest new prompts from known source", async () => {
 });
 
 it("ignores already ingested prompts", async () => {
-  const store = new OrbitStoreInMemory();
   await store.database.putEvents([
     mockQATask({
       eventID: "aaaaaaaaaaaaaaaaaaaaaa",
@@ -125,7 +128,6 @@ it("ignores already ingested prompts", async () => {
 });
 
 it("marks prompts as deleted", async () => {
-  const store = new OrbitStoreInMemory();
   await store.database.putEvents([
     mockQATask({
       eventID: "aaaaaaaaaaaaaaaaaaaaaa",
@@ -154,7 +156,6 @@ it("marks prompts as deleted", async () => {
 });
 
 it("only ingests specified sources", async () => {
-  const store = new OrbitStoreInMemory();
   await store.database.putEvents([
     mockQATask({
       eventID: "aaaaaaaaaaaaaaaaaaaaaa",

--- a/packages/ingester/src/ingest.ts
+++ b/packages/ingester/src/ingest.ts
@@ -1,0 +1,41 @@
+import { ColorPaletteName, EntityType, Task } from "@withorbit/core";
+import { DatabaseEntityQuery, OrbitStore } from "@withorbit/store-shared";
+
+/**
+ * @TJS-type string
+ * @TJS-pattern ^[0-9a-zA-Z_\-]{22}$
+ */
+type IngestibleSourceIdentifier = string & {
+  __sourceIDOpaqueType: never;
+};
+
+export interface IngestibleSource {
+  // unique identifier representing a source which tasks might share, used for clustering; can be a URL or an arbitrary UUID
+  identifier: IngestibleSourceIdentifier;
+  // title that can be used when displaying the source.
+  title: string;
+  // prompts associated with the given source
+  prompts: IngestiblePrompt[];
+  // an optional URL to open when the user indicates they'd like to navigate to the provenance of the task
+  url?: string;
+  // an optional const that can be used to customize the visual appearance of the source during review
+  colorPaletteName?: ColorPaletteName;
+}
+
+type IngestiblePrompt = IngestibleQAPrompt;
+
+export interface IngestibleQAPrompt {
+  body: { text: string };
+  answer: { text: string };
+}
+
+export async function ingestSources(
+  sources: IngestibleSource[],
+  store: OrbitStore,
+) {
+  const query: DatabaseEntityQuery<Task> = {
+    entityType: EntityType.Task,
+  };
+  const entities = await store.database.listEntities(query);
+  console.log(entities);
+}

--- a/packages/ingester/src/ingest.ts
+++ b/packages/ingester/src/ingest.ts
@@ -1,41 +1,154 @@
-import { ColorPaletteName, EntityType, Task } from "@withorbit/core";
+import {
+  EntityType,
+  Event,
+  EventType,
+  generateUniqueID,
+  QATaskContent,
+  Task,
+  TaskContent,
+  TaskContentType,
+  TaskIngestEvent,
+  TaskProvenance,
+  TaskSpecType,
+  TaskUpdateDeletedEvent,
+} from "@withorbit/core";
 import { DatabaseEntityQuery, OrbitStore } from "@withorbit/store-shared";
+import { IngestiblePrompt, IngestibleSource } from "./ingestibleSource";
 
-/**
- * @TJS-type string
- * @TJS-pattern ^[0-9a-zA-Z_\-]{22}$
- */
-type IngestibleSourceIdentifier = string & {
-  __sourceIDOpaqueType: never;
-};
-
-export interface IngestibleSource {
-  // unique identifier representing a source which tasks might share, used for clustering; can be a URL or an arbitrary UUID
-  identifier: IngestibleSourceIdentifier;
-  // title that can be used when displaying the source.
-  title: string;
-  // prompts associated with the given source
-  prompts: IngestiblePrompt[];
-  // an optional URL to open when the user indicates they'd like to navigate to the provenance of the task
-  url?: string;
-  // an optional const that can be used to customize the visual appearance of the source during review
-  colorPaletteName?: ColorPaletteName;
-}
-
-type IngestiblePrompt = IngestibleQAPrompt;
-
-export interface IngestibleQAPrompt {
-  body: { text: string };
-  answer: { text: string };
-}
-
+// TODO: handle moves across sources
+// TODO: handle provenance updates
 export async function ingestSources(
   sources: IngestibleSource[],
   store: OrbitStore,
 ) {
+  const events: Event[] = [];
+
+  // TODO: create a new query or extend the entity query such that
+  // we can filter on only sources that would have used this ingester
   const query: DatabaseEntityQuery<Task> = {
     entityType: EntityType.Task,
   };
   const entities = await store.database.listEntities(query);
-  console.log(entities);
+  const groupedEntities = groupEntitiesByIdentifiers(entities);
+  const timeMillis = Date.now();
+
+  for (const source of sources) {
+    if (groupedEntities[source.identifier]) {
+      // determine which prompts are new and which have been deleted
+      const existingPrompts = [...groupedEntities[source.identifier]];
+
+      for (const prompt of source.prompts) {
+        // NOTE: this `findIndex` is a bit expensive since it scans of each iteration.
+        // If this becomes a bottleneck we should precompute a hash for each task prompt.
+        const existingPromptIndex = existingPrompts.findIndex(
+          isOrbitTaskEqualToPrompt(prompt),
+        );
+        if (existingPromptIndex !== -1) {
+          // prompt already exists, remove from existing prompt search
+          existingPrompts.splice(existingPromptIndex, 1);
+        } else {
+          // prompt does not exist, lets ingest
+          events.push(createIngestTaskForSource(source, timeMillis)(prompt));
+        }
+      }
+
+      // mark all the prompts that still exist as deleted...
+      for (const existingPrompt of existingPrompts) {
+        events.push(createDeletePromptEvent(existingPrompt, timeMillis));
+      }
+    } else {
+      // completely new source, ingest each prompt
+      const ingestEvents = source.prompts.map(
+        createIngestTaskForSource(source, timeMillis),
+      );
+      events.push(...ingestEvents);
+    }
+  }
+  return events;
+}
+
+function groupEntitiesByIdentifiers(entities: Task<TaskContent>[]) {
+  const mapping: Record<TaskProvenance["identifier"], Task<TaskContent>[]> = {};
+  for (const entity of entities) {
+    const provenance = entity.provenance;
+    if (!provenance) continue;
+
+    if (mapping[provenance.identifier]) {
+      mapping[provenance.identifier].push(entity);
+    } else {
+      mapping[provenance.identifier] = [entity];
+    }
+  }
+  return mapping;
+}
+
+function createIngestTaskForSource(
+  source: IngestibleSource,
+  insertTimestampMilis: number,
+): (prompt: IngestiblePrompt) => TaskIngestEvent {
+  const provenance: TaskProvenance = {
+    identifier: source.identifier,
+    // TODO: we should allow prompts to specify an optional title. If
+    // they do, then we set this title to be the containerTitle
+    title: source.title,
+    ...(source.url ? { url: source.url } : {}),
+    ...(source.colorPaletteName
+      ? { colorPaletteName: source.colorPaletteName }
+      : {}),
+  };
+  return (prompt) => {
+    const content: QATaskContent = {
+      type: TaskContentType.QA,
+      body: {
+        text: prompt.body.text,
+        attachments: [],
+      },
+      answer: {
+        text: prompt.answer.text,
+        attachments: [],
+      },
+    };
+    return {
+      id: generateUniqueID(),
+      type: EventType.TaskIngest,
+      spec: {
+        type: TaskSpecType.Memory,
+        content,
+      },
+      // TODO: allow the interpreter to provide a stable identifier alongside prompts
+      // use random generation as a fallback. This will allow us to track moves across sources.
+      entityID: generateUniqueID(),
+      timestampMillis: insertTimestampMilis,
+      provenance,
+    };
+  };
+}
+
+function createDeletePromptEvent(
+  task: Task<TaskContent>,
+  timestampMillis: number,
+): TaskUpdateDeletedEvent {
+  return {
+    type: EventType.TaskUpdateDeleted,
+    id: generateUniqueID(),
+    entityID: task.id,
+    timestampMillis,
+    isDeleted: true,
+  };
+}
+
+function isOrbitTaskEqualToPrompt(
+  prompt: IngestiblePrompt,
+): (task: Task<TaskContent>) => boolean | undefined {
+  return (task) => {
+    if (task.spec.content.type === TaskContentType.QA && prompt.type === "qa") {
+      // they both are QA prompts, do they have the same content?
+      const taskContent = task.spec.content;
+      return (
+        taskContent.body.text === prompt.body.text &&
+        taskContent.answer.text === prompt.answer.text
+      );
+    }
+    return false;
+  };
 }

--- a/packages/ingester/src/ingest.ts
+++ b/packages/ingester/src/ingest.ts
@@ -13,7 +13,7 @@ import {
   TaskUpdateDeletedEvent,
 } from "@withorbit/core";
 import { DatabaseEntityQuery, OrbitStore } from "@withorbit/store-shared";
-import { IngestiblePrompt, IngestibleSource } from "./ingestibleSource";
+import { IngestiblePrompt, IngestibleSource } from "./ingestible";
 
 // TODO: handle moves across sources
 // TODO: handle provenance updates

--- a/packages/ingester/src/ingest.ts
+++ b/packages/ingester/src/ingest.ts
@@ -97,19 +97,20 @@ function groupEntitiesByProvenanceIdentifiers(entities: Task<TaskContent>[]) {
 }
 
 function groupEntitiesBySourceIdentifiers(entities: Task<TaskContent>[]) {
-  const mapping: Record<IngestibleItemIdentifier, Task<TaskContent>> = {};
+  // [01/05/22]: our current versin of typescript does not allow
+  // `IngestibleItemIdentifier` to be the key of an object. Newer
+  // releases of typescript support this behavior.
+  // https://github.com/microsoft/TypeScript/pull/44512
+  const mapping: Record<string, Task<TaskContent>> = {};
   for (const entity of entities) {
-    const _sourceID = entity.metadata[INGEST_SOURCE_IDENTIFIER_KEY];
-    if (!_sourceID) continue;
-    const sourceID = _sourceID as IngestibleItemIdentifier;
-
+    const sourceID = entity.metadata[INGEST_SOURCE_IDENTIFIER_KEY];
     mapping[sourceID] = entity;
   }
   return mapping;
 }
 
 function groupIngestibleItemsBySourceIdentifiers(items: IngestibleItem[]) {
-  const mapping: Record<IngestibleItemIdentifier, IngestibleItem> = {};
+  const mapping: Record<string, IngestibleItem> = {};
   for (const item of items) {
     mapping[item.identifier] = item;
   }

--- a/packages/ingester/src/ingest.ts
+++ b/packages/ingester/src/ingest.ts
@@ -3,23 +3,34 @@ import {
   Event,
   EventType,
   generateUniqueID,
-  QATaskContent,
   Task,
   TaskContent,
-  TaskContentType,
   TaskIngestEvent,
   TaskProvenance,
-  TaskSpecType,
   TaskUpdateDeletedEvent,
 } from "@withorbit/core";
 import { DatabaseEntityQuery, OrbitStore } from "@withorbit/store-shared";
-import { IngestiblePrompt, IngestibleSource } from "./ingestible";
+import {
+  IngestibleItem,
+  IngestibleItemIdentifier,
+  IngestibleSource,
+} from "./ingestible";
+
+type IngestOptions = {
+  ingestDateMilis: number;
+};
+const DEFAULT_OPTIONS = (): IngestOptions => ({
+  ingestDateMilis: Date.now(),
+});
+
+export const INGEST_SOURCE_IDENTIFIER_KEY = "ingest_source_identifier" as const;
 
 // TODO: handle moves across sources
 // TODO: handle provenance updates
 export async function ingestSources(
   sources: IngestibleSource[],
   store: OrbitStore,
+  opts: IngestOptions = DEFAULT_OPTIONS(),
 ) {
   const events: Event[] = [];
 
@@ -29,36 +40,39 @@ export async function ingestSources(
     entityType: EntityType.Task,
   };
   const entities = await store.database.listEntities(query);
-  const groupedEntities = groupEntitiesByIdentifiers(entities);
-  const timeMillis = Date.now();
+  const groupedEntities = groupEntitiesByProvenanceIdentifiers(entities);
+  const timeMillis = opts.ingestDateMilis;
 
   for (const source of sources) {
     if (groupedEntities[source.identifier]) {
       // determine which prompts are new and which have been deleted
-      const existingPrompts = [...groupedEntities[source.identifier]];
+      const existingPrompts = groupEntitiesBySourceIdentifiers(
+        groupedEntities[source.identifier],
+      );
+      const newPrompts = groupIngestibleItemsBySourceIdentifiers(source.items);
 
-      for (const prompt of source.prompts) {
-        // NOTE: this `findIndex` is a bit expensive since it scans of each iteration.
-        // If this becomes a bottleneck we should precompute a hash for each task prompt.
-        const existingPromptIndex = existingPrompts.findIndex(
-          isOrbitTaskEqualToPrompt(prompt),
-        );
-        if (existingPromptIndex !== -1) {
-          // prompt already exists, remove from existing prompt search
-          existingPrompts.splice(existingPromptIndex, 1);
-        } else {
-          // prompt does not exist, lets ingest
-          events.push(createIngestTaskForSource(source, timeMillis)(prompt));
+      // determine which tasks are newly added
+      for (const [key, potentialNewPrompt] of Object.entries(newPrompts)) {
+        if (!existingPrompts[key as IngestibleItemIdentifier]) {
+          // task is new
+          events.push(
+            createIngestTaskForSource(source, timeMillis)(potentialNewPrompt),
+          );
         }
       }
 
-      // mark all the prompts that still exist as deleted...
-      for (const existingPrompt of existingPrompts) {
-        events.push(createDeletePromptEvent(existingPrompt, timeMillis));
+      // determine which task have been deleted
+      for (const [key, existingPrompt] of Object.entries(existingPrompts)) {
+        if (!newPrompts[key as IngestibleItemIdentifier]) {
+          // task has been deleted within
+          // TODO: before marking as deleted, check if this ID is a new ingest event
+          // for another. If so, convert event to be a provenance update.
+          events.push(createDeletePromptEvent(existingPrompt, timeMillis));
+        }
       }
     } else {
       // completely new source, ingest each prompt
-      const ingestEvents = source.prompts.map(
+      const ingestEvents = source.items.map(
         createIngestTaskForSource(source, timeMillis),
       );
       events.push(...ingestEvents);
@@ -67,7 +81,7 @@ export async function ingestSources(
   return events;
 }
 
-function groupEntitiesByIdentifiers(entities: Task<TaskContent>[]) {
+function groupEntitiesByProvenanceIdentifiers(entities: Task<TaskContent>[]) {
   const mapping: Record<TaskProvenance["identifier"], Task<TaskContent>[]> = {};
   for (const entity of entities) {
     const provenance = entity.provenance;
@@ -82,44 +96,51 @@ function groupEntitiesByIdentifiers(entities: Task<TaskContent>[]) {
   return mapping;
 }
 
+function groupEntitiesBySourceIdentifiers(entities: Task<TaskContent>[]) {
+  const mapping: Record<IngestibleItemIdentifier, Task<TaskContent>> = {};
+  for (const entity of entities) {
+    const _sourceID = entity.metadata[INGEST_SOURCE_IDENTIFIER_KEY];
+    if (!_sourceID) continue;
+    const sourceID = _sourceID as IngestibleItemIdentifier;
+
+    mapping[sourceID] = entity;
+  }
+  return mapping;
+}
+
+function groupIngestibleItemsBySourceIdentifiers(items: IngestibleItem[]) {
+  const mapping: Record<IngestibleItemIdentifier, IngestibleItem> = {};
+  for (const item of items) {
+    mapping[item.identifier] = item;
+  }
+  return mapping;
+}
+
 function createIngestTaskForSource(
   source: IngestibleSource,
   insertTimestampMilis: number,
-): (prompt: IngestiblePrompt) => TaskIngestEvent {
+): (item: IngestibleItem) => TaskIngestEvent {
   const provenance: TaskProvenance = {
     identifier: source.identifier,
-    // TODO: we should allow prompts to specify an optional title. If
-    // they do, then we set this title to be the containerTitle
     title: source.title,
     ...(source.url ? { url: source.url } : {}),
     ...(source.colorPaletteName
       ? { colorPaletteName: source.colorPaletteName }
       : {}),
   };
-  return (prompt) => {
-    const content: QATaskContent = {
-      type: TaskContentType.QA,
-      body: {
-        text: prompt.body.text,
-        attachments: [],
-      },
-      answer: {
-        text: prompt.answer.text,
-        attachments: [],
-      },
-    };
+  return (item) => {
     return {
       id: generateUniqueID(),
       type: EventType.TaskIngest,
-      spec: {
-        type: TaskSpecType.Memory,
-        content,
-      },
-      // TODO: allow the interpreter to provide a stable identifier alongside prompts
-      // use random generation as a fallback. This will allow us to track moves across sources.
+      spec: item.spec,
       entityID: generateUniqueID(),
       timestampMillis: insertTimestampMilis,
-      provenance,
+      metadata: {
+        [INGEST_SOURCE_IDENTIFIER_KEY]: source.identifier,
+      },
+      provenance: {
+        ...provenance,
+      },
     };
   };
 }
@@ -134,21 +155,5 @@ function createDeletePromptEvent(
     entityID: task.id,
     timestampMillis,
     isDeleted: true,
-  };
-}
-
-function isOrbitTaskEqualToPrompt(
-  prompt: IngestiblePrompt,
-): (task: Task<TaskContent>) => boolean | undefined {
-  return (task) => {
-    if (task.spec.content.type === TaskContentType.QA && prompt.type === "qa") {
-      // they both are QA prompts, do they have the same content?
-      const taskContent = task.spec.content;
-      return (
-        taskContent.body.text === prompt.body.text &&
-        taskContent.answer.text === prompt.answer.text
-      );
-    }
-    return false;
   };
 }

--- a/packages/ingester/src/ingestible.json
+++ b/packages/ingester/src/ingestible.json
@@ -88,18 +88,21 @@
                     "type": "string"
                 },
                 "identifier": {
-                    "pattern": "^[0-9a-zA-Z_\\-]{22}$",
                     "type": "string"
                 },
                 "items": {
                     "items": {
                         "additionalProperties": false,
                         "properties": {
+                            "identifier": {
+                                "type": "string"
+                            },
                             "spec": {
                                 "$ref": "#/definitions/TaskSpec<TaskContent>"
                             }
                         },
                         "required": [
+                            "identifier",
                             "spec"
                         ],
                         "type": "object"

--- a/packages/ingester/src/ingestible.json
+++ b/packages/ingester/src/ingestible.json
@@ -1,0 +1,104 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "additionalProperties": false,
+    "definitions": {
+        "IngestibleQAPrompt": {
+            "additionalProperties": false,
+            "properties": {
+                "answer": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "text": {
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "text"
+                    ],
+                    "type": "object"
+                },
+                "body": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "text": {
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "text"
+                    ],
+                    "type": "object"
+                },
+                "type": {
+                    "enum": [
+                        "qa"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "answer",
+                "body",
+                "type"
+            ],
+            "type": "object"
+        },
+        "IngestibleSource": {
+            "additionalProperties": false,
+            "properties": {
+                "colorPaletteName": {
+                    "enum": [
+                        "blue",
+                        "brown",
+                        "cyan",
+                        "green",
+                        "lime",
+                        "orange",
+                        "pink",
+                        "purple",
+                        "red",
+                        "turquoise",
+                        "violet",
+                        "yellow"
+                    ],
+                    "type": "string"
+                },
+                "identifier": {
+                    "pattern": "^[0-9a-zA-Z_\\-]{22}$",
+                    "type": "string"
+                },
+                "prompts": {
+                    "items": {
+                        "$ref": "#/definitions/IngestibleQAPrompt"
+                    },
+                    "type": "array"
+                },
+                "title": {
+                    "type": "string"
+                },
+                "url": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "identifier",
+                "prompts",
+                "title"
+            ],
+            "type": "object"
+        }
+    },
+    "properties": {
+        "sources": {
+            "items": {
+                "$ref": "#/definitions/IngestibleSource"
+            },
+            "type": "array"
+        }
+    },
+    "required": [
+        "sources"
+    ],
+    "type": "object"
+}
+

--- a/packages/ingester/src/ingestible.json
+++ b/packages/ingester/src/ingestible.json
@@ -2,44 +2,68 @@
     "$schema": "http://json-schema.org/draft-07/schema#",
     "additionalProperties": false,
     "definitions": {
-        "IngestibleQAPrompt": {
+        "ClozeTaskContent": {
             "additionalProperties": false,
             "properties": {
-                "answer": {
-                    "additionalProperties": false,
-                    "properties": {
-                        "text": {
-                            "type": "string"
-                        }
-                    },
-                    "required": [
-                        "text"
-                    ],
-                    "type": "object"
-                },
                 "body": {
-                    "additionalProperties": false,
-                    "properties": {
-                        "text": {
-                            "type": "string"
-                        }
+                    "$ref": "#/definitions/TaskContentField"
+                },
+                "components": {
+                    "additionalProperties": {
+                        "$ref": "#/definitions/ClozeTaskContentComponent"
                     },
-                    "required": [
-                        "text"
-                    ],
                     "type": "object"
                 },
                 "type": {
                     "enum": [
-                        "qa"
+                        "cloze"
                     ],
                     "type": "string"
                 }
             },
             "required": [
-                "answer",
                 "body",
+                "components",
                 "type"
+            ],
+            "type": "object"
+        },
+        "ClozeTaskContentComponent": {
+            "additionalProperties": false,
+            "properties": {
+                "order": {
+                    "type": "number"
+                },
+                "ranges": {
+                    "items": {
+                        "additionalProperties": false,
+                        "properties": {
+                            "hint": {
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "length": {
+                                "type": "number"
+                            },
+                            "startIndex": {
+                                "type": "number"
+                            }
+                        },
+                        "required": [
+                            "hint",
+                            "length",
+                            "startIndex"
+                        ],
+                        "type": "object"
+                    },
+                    "type": "array"
+                }
+            },
+            "required": [
+                "order",
+                "ranges"
             ],
             "type": "object"
         },
@@ -67,9 +91,18 @@
                     "pattern": "^[0-9a-zA-Z_\\-]{22}$",
                     "type": "string"
                 },
-                "prompts": {
+                "items": {
                     "items": {
-                        "$ref": "#/definitions/IngestibleQAPrompt"
+                        "additionalProperties": false,
+                        "properties": {
+                            "spec": {
+                                "$ref": "#/definitions/TaskSpec<TaskContent>"
+                            }
+                        },
+                        "required": [
+                            "spec"
+                        ],
+                        "type": "object"
                     },
                     "type": "array"
                 },
@@ -82,8 +115,99 @@
             },
             "required": [
                 "identifier",
-                "prompts",
+                "items",
                 "title"
+            ],
+            "type": "object"
+        },
+        "PlainTaskContent": {
+            "additionalProperties": false,
+            "properties": {
+                "body": {
+                    "$ref": "#/definitions/TaskContentField"
+                },
+                "type": {
+                    "enum": [
+                        "plain"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "body",
+                "type"
+            ],
+            "type": "object"
+        },
+        "QATaskContent": {
+            "additionalProperties": false,
+            "properties": {
+                "answer": {
+                    "$ref": "#/definitions/TaskContentField"
+                },
+                "body": {
+                    "$ref": "#/definitions/TaskContentField"
+                },
+                "type": {
+                    "enum": [
+                        "qa"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "answer",
+                "body",
+                "type"
+            ],
+            "type": "object"
+        },
+        "TaskContentField": {
+            "additionalProperties": false,
+            "properties": {
+                "attachments": {
+                    "items": {
+                        "pattern": "^[0-9a-zA-Z_\\-]{22}$",
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                "text": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "attachments",
+                "text"
+            ],
+            "type": "object"
+        },
+        "TaskSpec<TaskContent>": {
+            "additionalProperties": false,
+            "properties": {
+                "content": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/QATaskContent"
+                        },
+                        {
+                            "$ref": "#/definitions/ClozeTaskContent"
+                        },
+                        {
+                            "$ref": "#/definitions/PlainTaskContent"
+                        }
+                    ]
+                },
+                "type": {
+                    "enum": [
+                        "memory"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "content",
+                "type"
             ],
             "type": "object"
         }

--- a/packages/ingester/src/ingestible.ts
+++ b/packages/ingester/src/ingestible.ts
@@ -1,5 +1,9 @@
 import { ColorPaletteName } from "@withorbit/core";
 
+export type Ingestible = {
+  sources: IngestibleSource[];
+};
+
 /**
  * @TJS-type string
  * @TJS-pattern ^[0-9a-zA-Z_\-]{22}$

--- a/packages/ingester/src/ingestible.ts
+++ b/packages/ingester/src/ingestible.ts
@@ -1,4 +1,4 @@
-import { ColorPaletteName } from "@withorbit/core";
+import { ColorPaletteName, TaskSpec } from "@withorbit/core";
 
 export type Ingestible = {
   sources: IngestibleSource[];
@@ -17,18 +17,23 @@ export interface IngestibleSource {
   identifier: IngestibleSourceIdentifier;
   // title that can be used when displaying the source.
   title: string;
-  // prompts associated with the given source
-  prompts: IngestiblePrompt[];
+  // items associated with the given source
+  items: IngestibleItem[];
   // an optional URL to open when the user indicates they'd like to navigate to the provenance of the task
   url?: string;
   // an optional const that can be used to customize the visual appearance of the source during review
   colorPaletteName?: ColorPaletteName;
 }
 
-export type IngestiblePrompt = IngestibleQAPrompt;
+/**
+ * @TJS-type string
+ * @TJS-pattern ^[0-9a-zA-Z_\-]{22}$
+ */
+export type IngestibleItemIdentifier = string & {
+  __sourceIDOpaqueType: never;
+};
 
-export interface IngestibleQAPrompt {
-  type: "qa";
-  body: { text: string };
-  answer: { text: string };
-}
+export type IngestibleItem = {
+  identifier: IngestibleItemIdentifier;
+  spec: TaskSpec;
+};

--- a/packages/ingester/src/ingestible.ts
+++ b/packages/ingester/src/ingestible.ts
@@ -6,7 +6,6 @@ export type Ingestible = {
 
 /**
  * @TJS-type string
- * @TJS-pattern ^[0-9a-zA-Z_\-]{22}$
  */
 export type IngestibleSourceIdentifier = string & {
   __sourceIDOpaqueType: never;
@@ -27,7 +26,6 @@ export interface IngestibleSource {
 
 /**
  * @TJS-type string
- * @TJS-pattern ^[0-9a-zA-Z_\-]{22}$
  */
 export type IngestibleItemIdentifier = string & {
   __sourceIDOpaqueType: never;

--- a/packages/ingester/src/ingestibleSource.ts
+++ b/packages/ingester/src/ingestibleSource.ts
@@ -1,0 +1,30 @@
+import { ColorPaletteName } from "@withorbit/core";
+
+/**
+ * @TJS-type string
+ * @TJS-pattern ^[0-9a-zA-Z_\-]{22}$
+ */
+export type IngestibleSourceIdentifier = string & {
+  __sourceIDOpaqueType: never;
+};
+
+export interface IngestibleSource {
+  // unique identifier representing a source which tasks might share, used for clustering; can be a URL or an arbitrary UUID
+  identifier: IngestibleSourceIdentifier;
+  // title that can be used when displaying the source.
+  title: string;
+  // prompts associated with the given source
+  prompts: IngestiblePrompt[];
+  // an optional URL to open when the user indicates they'd like to navigate to the provenance of the task
+  url?: string;
+  // an optional const that can be used to customize the visual appearance of the source during review
+  colorPaletteName?: ColorPaletteName;
+}
+
+export type IngestiblePrompt = IngestibleQAPrompt;
+
+export interface IngestibleQAPrompt {
+  type: "qa";
+  body: { text: string };
+  answer: { text: string };
+}

--- a/packages/ingester/src/validateIngestible.test.ts
+++ b/packages/ingester/src/validateIngestible.test.ts
@@ -1,0 +1,35 @@
+import { createIngestibleValidator } from "./validateIngestible";
+
+it("accepts valid schema", () => {
+  const validator = createIngestibleValidator({
+    mutateWithDefaultValues: true,
+  });
+  const { isValid, errors } = validator.validate({
+    sources: [
+      {
+        identifier: "aaaaaaaaaaaaaaaaaaaaaa",
+        title: "Brand new source",
+        prompts: [
+          {
+            type: "qa",
+            body: { text: "Question" },
+            answer: { text: "Answer" },
+          },
+        ],
+      },
+    ],
+  });
+  expect(errors).toBeNull();
+  expect(isValid).toBeTruthy();
+});
+
+it("rejects invalid schema", () => {
+  const validator = createIngestibleValidator({
+    mutateWithDefaultValues: true,
+  });
+  const { isValid, errors } = validator.validate({});
+  expect(errors).toEqual([
+    { message: "must have required property 'sources'", path: "" },
+  ]);
+  expect(isValid).toBeFalsy();
+});

--- a/packages/ingester/src/validateIngestible.test.ts
+++ b/packages/ingester/src/validateIngestible.test.ts
@@ -11,6 +11,7 @@ it("accepts valid schema", () => {
         title: "Brand new source",
         items: [
           {
+            identifier: "identifier_item_A",
             spec: {
               type: "memory",
               content: {

--- a/packages/ingester/src/validateIngestible.test.ts
+++ b/packages/ingester/src/validateIngestible.test.ts
@@ -9,11 +9,16 @@ it("accepts valid schema", () => {
       {
         identifier: "aaaaaaaaaaaaaaaaaaaaaa",
         title: "Brand new source",
-        prompts: [
+        items: [
           {
-            type: "qa",
-            body: { text: "Question" },
-            answer: { text: "Answer" },
+            spec: {
+              type: "memory",
+              content: {
+                type: "qa",
+                body: { text: "Question", attachments: [] },
+                answer: { text: "Answer", attachments: [] },
+              },
+            },
           },
         ],
       },

--- a/packages/ingester/src/validateIngestible.ts
+++ b/packages/ingester/src/validateIngestible.ts
@@ -1,0 +1,40 @@
+import Ajv from "ajv";
+import schema from "./ingestible.json";
+import { Ingestible } from "./ingestible";
+
+type ValidationError = { path: string; message: string | null };
+export interface IngestibleValidator {
+  validate(value: unknown): {
+    isValid: boolean;
+    errors: ValidationError[] | null;
+  };
+}
+
+export function createIngestibleValidator(config: {
+  mutateWithDefaultValues: boolean;
+}): IngestibleValidator {
+  const ajv = new Ajv({
+    allowUnionTypes: true,
+    useDefaults: config.mutateWithDefaultValues,
+    // Coerce incoming values to the schema-specified types. When the schema
+    // specifies an array type, it will map x to [x] as needed.
+    //
+    // ex: let ids be defined as an array in the schema
+    // a value of { ids: "idA" } will be coerced to { ids: ["idA"] }
+    coerceTypes: "array",
+    verbose: true,
+  });
+
+  const validator = ajv.compile<Ingestible>(schema);
+  return {
+    validate: (value) => {
+      const isValid = validator(value);
+      const errors = validator.errors?.map((err) => ({
+        path: err.instancePath,
+        message: err.message ?? null,
+      }));
+
+      return { isValid, errors: errors ?? null };
+    },
+  };
+}

--- a/packages/ingester/tsconfig.json
+++ b/packages/ingester/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "extends": "../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "types": ["jest", "node"]
+  },
+  "include": ["./src/**/*.ts", "./src/**/*.json"],
+  "references": [
+    {
+      "path": "../core"
+    },
+    {
+      "path": "../store-shared"
+    },
+    {
+      "path": "../store-fs"
+    }
+  ]
+}

--- a/packages/store-fs/src/orbitStoreInMemory.ts
+++ b/packages/store-fs/src/orbitStoreInMemory.ts
@@ -15,6 +15,7 @@ export class OrbitStoreInMemory implements OrbitStore {
   constructor(eventReducer?: EventReducer) {
     const sqlDatabaseBackend = new SQLDatabaseBackend(
       SQLDatabaseBackend.inMemoryDBSubpath,
+      { enableDebugLogs: false },
     );
     this.database = new Database(sqlDatabaseBackend, eventReducer);
 

--- a/packages/store-fs/src/sqlite.ts
+++ b/packages/store-fs/src/sqlite.ts
@@ -44,10 +44,13 @@ export class SQLDatabaseBackend implements DatabaseBackend {
 
   static attachmentURLProtocol = "x-orbit-sqlattachment";
 
-  constructor(path: string) {
+  constructor(path: string, options?: { enableDebugLogs?: boolean }) {
     this._path = path;
     this._db = openDatabase(path);
-    this._migrationPromise = performMigration(this._db);
+    this._migrationPromise = performMigration(
+      this._db,
+      options?.enableDebugLogs ?? true,
+    );
   }
   static inMemoryDBSubpath = ":memory:"; // Pass to constructor to create an in-memory database
   static tempDBSubpath = ""; // Pass to constructor to create a temporary database file

--- a/packages/store-fs/src/sqlite/migration.ts
+++ b/packages/store-fs/src/sqlite/migration.ts
@@ -6,15 +6,22 @@ import { SQLDatabase } from "./types";
 
 export async function performMigration(
   db: SQLDatabase,
+  logProgress?: boolean,
   throughSchemaVersionNumber?: number,
 ): Promise<void> {
   const currentVersion = await getSchemaVersionNumber(db);
+
+  const debugLog = (str: string) => {
+    if (logProgress) {
+      console.log(str);
+    }
+  };
 
   await execTransaction(db, (tx) => {
     const targetVersionNumber =
       throughSchemaVersionNumber ?? latestSchemaVersionNumber;
     if (currentVersion < targetVersionNumber) {
-      console.log(
+      debugLog(
         `Starting migration from ${currentVersion} to ${targetVersionNumber}`,
       );
       let lastVersionNumber = currentVersion;
@@ -25,7 +32,7 @@ export async function performMigration(
         migrationIndex++
       ) {
         const migration = migrations[migrationIndex];
-        console.log(`Migrating to ${migration.version}`);
+        debugLog(`Migrating to ${migration.version}`);
         for (const statement of migration.statements) {
           tx.executeSql(statement);
         }

--- a/packages/tsconfig.json
+++ b/packages/tsconfig.json
@@ -7,6 +7,7 @@
     { "path": "./backend" },
     { "path": "./core" },
     { "path": "./embedded-support" },
+    { "path": "./ingester" },
     { "path": "./ui" },
     { "path": "./note-sync" },
     { "path": "./sample-data" },


### PR DESCRIPTION
Closes https://github.com/andymatuschak/orbit/issues/260

## What
This PR defines a new package called `Ingester` which outlines an intermediate file format to sync prompts to an `OrbitStore`.

## Why
Having this intermediate file format allows for the decoupling between source parsing and syncing. 

## What is the format?
```typescript
export type Ingestible = {
  sources: IngestibleSource[];
};

export interface IngestibleSource {
  // unique identifier representing a source which tasks might share, used for clustering; can be a URL or an arbitrary UUID
  identifier: IngestibleSourceIdentifier;
  // title that can be used when displaying the source.
  title: string;
  // prompts associated with the given source
  prompts: IngestiblePrompt[];
  // an optional URL to open when the user indicates they'd like to navigate to the provenance of the task
  url?: string;
  // an optional const that can be used to customize the visual appearance of the source during review
  colorPaletteName?: ColorPaletteName;
}
```

In this schema, producers (Anki, Bear, General Markdown, Biome) generate an "ingestible" file which are associated with an arbitrary number of sources. Prompts are associated with sources. Bear might produce a source per note, while Anki might produce a source per deck. A producer generates a stable identifier for each source. The ingester package is responsible for diffing between the prompts in the Orbit store, and the ones provided by the producer.

I believe this current format strikes a good balance between the "inferred" vs. "explicit" problem that I attempted to enumerate in the original issue. In this model, a producer does not need to output the absolute set of prompts. It can instead only produce sources that need to be synced. Sources which are not provided, are **not considered**. See `ingest.test.ts` test cases which I think capture the expected usage of this API.

## How has this been tested?
I am currently working on porting the `note-sync` package to use this code on https://github.com/kirkbyo/orbit/commits/bear-import. That work should help give some confidence in that this API is sound. That being said, I do not have a large corpus of markdown files with embedded prompts (and not a Bear user at that), so if you have any ideas on how I could test this further let me know.
