### PR TITLE
Replicate behaviour of note-sync package to use ingester

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "scripts": {
     "build": "tsc -b packages/tsconfig.json && (cd packages/backend; yarn build)",
     "watch": "tsc -b -w packages/tsconfig.json",
-    "test": "cd packages; npx jest --projects anki-import api-client ingester backend core web-component note-sync api store-fs store-web --runInBand",
+    "test": "cd packages; npx jest --projects anki-import api-client ingester backend core web-component note-sync api store-fs store-web interpreter --runInBand",
     "test:watch": "yarn run test --watch",
     "lint": "cd packages; eslint .",
     "lint:fix": "cd packages; eslint --fix .",

--- a/packages/interpreter/LICENSE
+++ b/packages/interpreter/LICENSE
@@ -1,0 +1,175 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.

--- a/packages/interpreter/babel.config.cjs
+++ b/packages/interpreter/babel.config.cjs
@@ -1,0 +1,13 @@
+module.exports = {
+  presets: [
+    [
+      "@babel/preset-env",
+      {
+        targets: {
+          node: "current",
+        },
+      },
+    ],
+    "@babel/preset-typescript",
+  ],
+};

--- a/packages/interpreter/jest.config.cjs
+++ b/packages/interpreter/jest.config.cjs
@@ -1,0 +1,9 @@
+module.exports = {
+  testEnvironment: "node",
+  testMatch: ["**/?(*.)+(spec|test).ts?(x)"],
+  testPathIgnorePatterns: ["dist", "node_modules"],
+  transformIgnorePatterns: [],
+  transform: {
+    "\\.[jt]s$": ["babel-jest", { cwd: __dirname }],
+  },
+};

--- a/packages/interpreter/package.json
+++ b/packages/interpreter/package.json
@@ -1,0 +1,35 @@
+{
+  "name": "@withorbit/interpreter",
+  "version": "0.0.1",
+  "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "private": true,
+  "sideEffects": false,
+  "scripts": {
+    "build": "tsc -b",
+    "test": "jest",
+    "interpret": "yarn build; node --experimental-specifier-resolution=node dist/bin/run.js"
+  },
+  "dependencies": {
+    "@withorbit/core": "0.0.1",
+    "@withorbit/ingester": "0.0.1",
+    "@withorbit/store-fs": "0.0.1",
+    "remark-parse": "^10.0.1",
+    "remark-stringify": "^10.0.2",
+    "remark-wiki-link": "^1.0.4",
+    "unified": "^10.1.2",
+    "unist-util-parents": "^2.0.0",
+    "unist-util-select": "^4.0.1"
+  },
+  "devDependencies": {
+    "@babel/preset-env": "^7.16.11",
+    "@types/jest": "^26.0.24",
+    "@types/mdast": "^3.0.10",
+    "@types/node": "^14.14.7",
+    "@types/unist": "^2.0.6",
+    "babel-jest": "^27.0.6",
+    "jest": "^27.0.6",
+    "typescript": "^4.2.4"
+  }
+}

--- a/packages/interpreter/package.json
+++ b/packages/interpreter/package.json
@@ -15,12 +15,13 @@
     "@withorbit/core": "0.0.1",
     "@withorbit/ingester": "0.0.1",
     "@withorbit/store-fs": "0.0.1",
-    "remark-parse": "^10.0.1",
-    "remark-stringify": "^10.0.2",
+    "remark-parse": "10.0.0",
+    "remark-stringify": "10.0.0",
     "remark-wiki-link": "^1.0.4",
-    "unified": "^10.1.2",
+    "unified": "10.1.0",
+    "unist-util-map": "3.0.0",
     "unist-util-parents": "^2.0.0",
-    "unist-util-select": "^4.0.1"
+    "unist-util-select": "4.0.0"
   },
   "devDependencies": {
     "@babel/preset-env": "^7.16.11",

--- a/packages/interpreter/src/bin/run.ts
+++ b/packages/interpreter/src/bin/run.ts
@@ -1,0 +1,62 @@
+import { Ingestible } from "@withorbit/ingester";
+import fs from "fs";
+import path from "path";
+import { BearInterpreter } from "../interpreters";
+import { InterpretableFile, Interpreter } from "../interpreter";
+
+async function run(
+  noteDirectory: string,
+  interpreter: Interpreter,
+): Promise<Ingestible> {
+  // read and parse each file in the directory
+  const fileNames = await listNoteFiles(noteDirectory);
+  const files = await Promise.all(
+    fileNames.map(async (fileName): Promise<InterpretableFile> => {
+      const filePath = path.join(noteDirectory, fileName);
+      const content = await readFile(filePath);
+      return {
+        name: fileName,
+        path: filePath,
+        content,
+      };
+    }),
+  );
+  return interpreter.interpret(files);
+}
+
+async function listNoteFiles(folderPath: string): Promise<string[]> {
+  const noteDirectoryEntries = await fs.promises.readdir(folderPath, {
+    withFileTypes: true,
+  });
+  return noteDirectoryEntries
+    .filter(
+      (entry) =>
+        entry.isFile() &&
+        !entry.name.startsWith(".") &&
+        entry.name.endsWith(".md"),
+    )
+    .map((entry) => entry.name);
+}
+
+async function readFile(path: string): Promise<string> {
+  const buffer = await fs.promises.readFile(path);
+  return buffer.toString("utf-8");
+}
+
+(async () => {
+  // ensure that the arguments are defined
+  const noteDirectory = process.argv[2];
+  const outJsonFilePath = process.argv[3];
+  if (!noteDirectory || !outJsonFilePath) {
+    console.error("Usage: yarn ingest /path/to/notes /path/to/json-file");
+    process.exit(1);
+  }
+
+  const interpreter = new BearInterpreter();
+  const ingestible = await run(noteDirectory, interpreter);
+  await fs.promises.writeFile(outJsonFilePath, JSON.stringify(ingestible));
+})()
+  .then(() => {
+    process.exit(0);
+  })
+  .catch(console.error);

--- a/packages/interpreter/src/bin/run.ts
+++ b/packages/interpreter/src/bin/run.ts
@@ -49,7 +49,7 @@ async function readFile(path: string): Promise<string> {
   const noteDirectory = process.argv[2];
   const outJsonFilePath = process.argv[3];
   if (!noteDirectory || !outJsonFilePath) {
-    console.error("Usage: yarn ingest /path/to/notes /path/to/json-file");
+    console.error("Usage: yarn interpret /path/to/notes /path/to/json-file");
     process.exit(1);
   }
 

--- a/packages/interpreter/src/bin/run.ts
+++ b/packages/interpreter/src/bin/run.ts
@@ -3,6 +3,7 @@ import fs from "fs";
 import path from "path";
 import { BearInterpreter } from "../interpreters";
 import { InterpretableFile, Interpreter } from "../interpreter";
+import { CryptoBase64Hasher } from "../hasher/CryptoBase64Hasher";
 
 async function run(
   noteDirectory: string,
@@ -52,7 +53,7 @@ async function readFile(path: string): Promise<string> {
     process.exit(1);
   }
 
-  const interpreter = new BearInterpreter();
+  const interpreter = new BearInterpreter(CryptoBase64Hasher);
   const ingestible = await run(noteDirectory, interpreter);
   await fs.promises.writeFile(outJsonFilePath, JSON.stringify(ingestible));
 })()

--- a/packages/interpreter/src/hasher/CryptoBase64Hasher.test.ts
+++ b/packages/interpreter/src/hasher/CryptoBase64Hasher.test.ts
@@ -1,0 +1,59 @@
+import { TaskContentType, TaskSpec, TaskSpecType } from "@withorbit/core";
+import { CryptoBase64Hasher } from "./CryptoBase64Hasher";
+
+it("hashes", () => {
+  const object: TaskSpec = {
+    type: TaskSpecType.Memory,
+    content: {
+      type: TaskContentType.QA,
+      body: { text: "Question", attachments: [] },
+      answer: { text: "Answer", attachments: [] },
+    },
+  };
+  const hash = CryptoBase64Hasher.hash(object);
+  expect(hash).toEqual("Opkh3stAIIc1KOXWg2FeT+rp4fAJQ6vLEVNuN/f1Poc=");
+});
+
+it("is a function of TaskContentType", () => {
+  const objectA: TaskSpec = {
+    type: TaskSpecType.Memory,
+    content: {
+      type: TaskContentType.QA,
+      body: { text: "Question", attachments: [] },
+      answer: { text: "", attachments: [] },
+    },
+  };
+  const objectB: TaskSpec = {
+    type: TaskSpecType.Memory,
+    content: {
+      type: TaskContentType.Cloze,
+      body: { text: "Question", attachments: [] },
+      components: {},
+    },
+  };
+  const hashA = CryptoBase64Hasher.hash(objectA);
+  const hashB = CryptoBase64Hasher.hash(objectB);
+  expect(hashA).not.toEqual(hashB);
+});
+
+it("is not sensitive to key ordering", () => {
+  const objectA: TaskSpec = {
+    type: TaskSpecType.Memory,
+    content: {
+      type: TaskContentType.QA,
+      body: { text: "Question", attachments: [] },
+      answer: { text: "Answer", attachments: [] },
+    },
+  };
+  const objectB: TaskSpec = {
+    content: {
+      answer: { attachments: [], text: "Answer" },
+      type: TaskContentType.QA,
+      body: { text: "Question", attachments: [] },
+    },
+    type: TaskSpecType.Memory,
+  };
+  const hashA = CryptoBase64Hasher.hash(objectA);
+  const hashB = CryptoBase64Hasher.hash(objectB);
+  expect(hashA).toEqual(hashB);
+});

--- a/packages/interpreter/src/hasher/CryptoBase64Hasher.ts
+++ b/packages/interpreter/src/hasher/CryptoBase64Hasher.ts
@@ -1,0 +1,42 @@
+import {
+  ClozeTaskContent,
+  PlainTaskContent,
+  QATaskContent,
+  TaskContent,
+  TaskContentType,
+  TaskSpec,
+} from "@withorbit/core";
+import crypto from "crypto";
+import { Hasher } from "./hasher";
+
+// normalize each of the object into an array of strings to ensure
+// that the hash is not sensitive to key ordering
+const taskContentDeterministicOrder: {
+  [key in TaskContentType]: (spec: TaskContent) => string[];
+} = {
+  [TaskContentType.QA]: (content) => {
+    const qa = content as QATaskContent;
+    return [content.type, qa.body.text, qa.answer.text];
+  },
+  [TaskContentType.Cloze]: (content) => {
+    const cloze = content as ClozeTaskContent;
+    return [content.type, cloze.body.text];
+  },
+  [TaskContentType.Plain]: (content) => {
+    const plain = content as PlainTaskContent;
+    return [content.type, plain.body.text];
+  },
+};
+
+export const CryptoBase64Hasher: Hasher = {
+  hash(spec: TaskSpec): string {
+    let ordering = taskContentDeterministicOrder[spec.content.type](
+      spec.content,
+    );
+    ordering = [spec.type, ...ordering];
+    return crypto
+      .createHash("sha256")
+      .update(JSON.stringify(ordering))
+      .digest("base64");
+  },
+};

--- a/packages/interpreter/src/hasher/CryptoBase64Hasher.ts
+++ b/packages/interpreter/src/hasher/CryptoBase64Hasher.ts
@@ -9,7 +9,7 @@ import {
 import crypto from "crypto";
 import { Hasher } from "./hasher";
 
-// normalize each of the object into an array of strings to ensure
+// normalize each of the objects into an array of strings to ensure
 // that the hash is not sensitive to key ordering
 const taskContentDeterministicOrder: {
   [key in TaskContentType]: (spec: TaskContent) => string[];

--- a/packages/interpreter/src/hasher/hasher.ts
+++ b/packages/interpreter/src/hasher/hasher.ts
@@ -1,0 +1,5 @@
+import { TaskSpec } from "@withorbit/core";
+
+export interface Hasher {
+  hash(spec: TaskSpec): string;
+}

--- a/packages/interpreter/src/interpreter.ts
+++ b/packages/interpreter/src/interpreter.ts
@@ -1,0 +1,11 @@
+import { Ingestible } from "@withorbit/ingester";
+
+export interface Interpreter {
+  interpret(files: InterpretableFile[]): Promise<Ingestible>;
+}
+
+export type InterpretableFile = {
+  name: string;
+  path: string;
+  content: string;
+};

--- a/packages/interpreter/src/interpreter.ts
+++ b/packages/interpreter/src/interpreter.ts
@@ -1,3 +1,4 @@
+import { TaskSpec } from "@withorbit/core";
 import { Ingestible } from "@withorbit/ingester";
 
 export interface Interpreter {

--- a/packages/interpreter/src/interpreter.ts
+++ b/packages/interpreter/src/interpreter.ts
@@ -1,4 +1,3 @@
-import { TaskSpec } from "@withorbit/core";
 import { Ingestible } from "@withorbit/ingester";
 
 export interface Interpreter {

--- a/packages/interpreter/src/interpreters/bear/BearInterpreter.test.ts
+++ b/packages/interpreter/src/interpreters/bear/BearInterpreter.test.ts
@@ -1,0 +1,29 @@
+import { CryptoBase64Hasher } from "../../hasher/CryptoBase64Hasher";
+import { InterpretableFile } from "../../interpreter";
+import { BearInterpreter } from "./BearInterpreter";
+
+it("interprets file with mixed content", async () => {
+  const file: InterpretableFile = {
+    name: "Hello World.md",
+    path: "/some/file/path/Hello World.md",
+    content: `# Hello World
+
+This is an example document which will contain both normal prompts and cloze prompts.
+    
+Q. What is the influence of A on B?
+A. It makes B harder to read w.r.t A
+    
+This is another paragraph.
+    
+Q. This is another prompt.
+A. Which contains a completely valid answer.
+    
+This is a {test} cloze prompt
+    
+<!-- {BearID:0DE4CB36-2EFC-4207-9074-667CBAE25ABB-12048-0000D97D373A46D2} -->`,
+  };
+  const interpreter = new BearInterpreter(CryptoBase64Hasher);
+  const ingestible = await interpreter.interpret([file]);
+  expect(ingestible.sources).toHaveLength(1);
+  expect(ingestible.sources[0]).toMatchSnapshot();
+});

--- a/packages/interpreter/src/interpreters/bear/BearInterpreter.ts
+++ b/packages/interpreter/src/interpreters/bear/BearInterpreter.ts
@@ -34,11 +34,11 @@ export class BearInterpreter implements Interpreter {
           const noteTitle = getNoteTitle(root);
 
           return {
-            identifier: (bearId?.id ?? file.path) as IngestibleSourceIdentifier,
+            identifier: bearId.id as IngestibleSourceIdentifier,
             title: noteTitle ?? file.name,
             url: bearId.openURL,
             items: prompts.map((prompt): IngestibleItem => {
-              const spec = convertInterpreterPromptToIngestable(prompt);
+              const spec = convertInterpreterPromptToIngestible(prompt);
               const identifier = this._hasher.hash(
                 spec,
               ) as IngestibleItemIdentifier;
@@ -57,7 +57,7 @@ export class BearInterpreter implements Interpreter {
   }
 }
 
-function convertInterpreterPromptToIngestable(prompt: Prompt): TaskSpec {
+function convertInterpreterPromptToIngestible(prompt: Prompt): TaskSpec {
   if (prompt.type === "qaPrompt") {
     return {
       type: TaskSpecType.Memory,

--- a/packages/interpreter/src/interpreters/bear/BearInterpreter.ts
+++ b/packages/interpreter/src/interpreters/bear/BearInterpreter.ts
@@ -1,0 +1,49 @@
+import {
+  Ingestible,
+  IngestiblePrompt,
+  IngestibleSource,
+  IngestibleSourceIdentifier,
+} from "@withorbit/ingester";
+import { InterpretableFile, Interpreter } from "../../interpreter";
+import { findAllPrompts, parseMarkdown, processor, Prompt } from "./markdown";
+import { getNoteTitle } from "./utils/getNoteTitle";
+import { getStableBearID } from "./utils/getStableBearID";
+
+export class BearInterpreter implements Interpreter {
+  async interpret(files: InterpretableFile[]): Promise<Ingestible> {
+    const sources = await Promise.all(
+      files.map(async (file): Promise<IngestibleSource> => {
+        const root = await parseMarkdown(file.content);
+        const prompts = findAllPrompts(root);
+        const bearId = getStableBearID(root);
+        const noteTitle = getNoteTitle(root);
+
+        return {
+          identifier: (bearId?.id ?? file.path) as IngestibleSourceIdentifier,
+          title: noteTitle ?? file.name,
+          prompts: prompts.map(convertInterpreterPromptToIngestable),
+        };
+      }),
+    );
+    return { sources };
+  }
+}
+
+function convertInterpreterPromptToIngestable(
+  prompt: Prompt,
+): IngestiblePrompt {
+  if (prompt.type === "qaPrompt") {
+    return {
+      type: "qa",
+      body: {
+        // @ts-expect-error typings are wrong on this function
+        text: processor.stringify(prompt.question).trimRight(),
+      },
+      answer: {
+        // @ts-expect-error typings are wrong on this function
+        text: processor.stringify(prompt.answer).trimRight(),
+      },
+    };
+  }
+  throw new Error(`unsupported prompt type: ${prompt.type}`);
+}

--- a/packages/interpreter/src/interpreters/bear/__snapshots__/BearInterpreter.test.ts.snap
+++ b/packages/interpreter/src/interpreters/bear/__snapshots__/BearInterpreter.test.ts.snap
@@ -1,0 +1,70 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`interprets file with mixed content 1`] = `
+Object {
+  "identifier": "0DE4CB36-2EFC-4207-9074-667CBAE25ABB-12048-0000D97D373A46D2",
+  "items": Array [
+    Object {
+      "identifier": "wCdCGztny92Q8YVxMJGBeBxe/M0X6XNCH0gIigTO2jc=",
+      "spec": Object {
+        "content": Object {
+          "body": Object {
+            "attachments": Array [],
+            "text": "This is a test cloze prompt",
+          },
+          "components": Object {
+            "0": Object {
+              "order": 0,
+              "ranges": Array [
+                Object {
+                  "hint": null,
+                  "length": 4,
+                  "startIndex": 10,
+                },
+              ],
+            },
+          },
+          "type": "cloze",
+        },
+        "type": "memory",
+      },
+    },
+    Object {
+      "identifier": "HsSkb6EQxnC4lUPQ66v1yjarOgo5aSXQPZ3QNErckGw=",
+      "spec": Object {
+        "content": Object {
+          "answer": Object {
+            "attachments": Array [],
+            "text": "It makes B harder to read w.r.t A",
+          },
+          "body": Object {
+            "attachments": Array [],
+            "text": "What is the influence of A on B?",
+          },
+          "type": "qa",
+        },
+        "type": "memory",
+      },
+    },
+    Object {
+      "identifier": "IolmfjQEMhQ7/rivRDy23KqggsnH9RI51WuR78zMcwg=",
+      "spec": Object {
+        "content": Object {
+          "answer": Object {
+            "attachments": Array [],
+            "text": "Which contains a completely valid answer.",
+          },
+          "body": Object {
+            "attachments": Array [],
+            "text": "This is another prompt.",
+          },
+          "type": "qa",
+        },
+        "type": "memory",
+      },
+    },
+  ],
+  "title": "Hello World",
+  "url": "bear://x-callback-url/open-note?id=0DE4CB36-2EFC-4207-9074-667CBAE25ABB-12048-0000D97D373A46D2",
+}
+`;

--- a/packages/interpreter/src/interpreters/bear/markdown.test.ts
+++ b/packages/interpreter/src/interpreters/bear/markdown.test.ts
@@ -1,0 +1,66 @@
+import { selectAll } from "unist-util-select";
+import {
+  clozeNodeType,
+  ClozePrompt,
+  ClozePromptNode,
+  clozePromptType,
+  findAllPrompts,
+  qaPromptType,
+  processor,
+} from "./markdown";
+
+function getPrompts(input: string) {
+  return findAllPrompts(processor.runSync(processor.parse(input)));
+}
+
+test("double cloze", () => {
+  const prompts = getPrompts(`# Heading
+  
+  This paragraph {has two} cloze {prompts}.
+  
+  This one has none.`);
+
+  expect(prompts).toHaveLength(1);
+  const prompt = prompts[0] as ClozePrompt;
+  expect(prompt.type).toEqual(clozePromptType);
+  expect(prompt.block.type).toBe("paragraph");
+  const clozeNodes = selectAll(clozeNodeType, prompt.block);
+  expect(clozeNodes).toHaveLength(2);
+  expect((clozeNodes[1] as ClozePromptNode).children).toMatchObject([
+    { type: "text", value: "prompts" },
+  ]);
+});
+
+test("two clozes", () => {
+  const prompts = getPrompts(`# Heading
+  
+  This paragraph {has} a cloze prompt.
+  
+  This one has {another}.`);
+
+  expect(prompts).toHaveLength(2);
+  expect(prompts[0]).not.toEqual(prompts[1]);
+});
+
+test("QA prompt", () => {
+  const prompts = getPrompts(`# Heading
+  
+Q. This is a question.
+A. This is an answer.
+  
+This is another paragraph`);
+
+  expect(prompts).toHaveLength(1);
+  expect(prompts[0].type).toEqual(qaPromptType);
+});
+
+test("cloze in backlink section", () => {
+  const prompts = getPrompts(`# Heading
+  
+## Backlinks
+* [[Source link]]
+\t* Some context {with a cloze} link.
+`);
+
+  expect(prompts).toHaveLength(0);
+});

--- a/packages/interpreter/src/interpreters/bear/markdown.ts
+++ b/packages/interpreter/src/interpreters/bear/markdown.ts
@@ -1,0 +1,145 @@
+import unist from "unist";
+import mdast from "mdast";
+import remarkParse from "remark-parse";
+import remarkStringify from "remark-stringify";
+import { unified } from "unified";
+import { parents } from "unist-util-parents";
+import * as unistUtilSelect from "unist-util-select";
+import noteLinkProcessorPlugin from "./plugins/noteLinkProcessorPlugin";
+import backlinksPlugin from "./plugins/backlinksPlugin";
+import bearIDPlugin from "./plugins/bearIDPlugin";
+import clozePromptPlugin from "./plugins/clozePromptPlugin";
+import qaPromptPlugin from "./plugins/qaPromptPlugin";
+
+export type JsonArray = Array<AnyJson>;
+export type AnyJson = boolean | number | string | null | JsonArray | JsonMap;
+export interface JsonMap {
+  [key: string]: AnyJson;
+}
+
+export const clozePromptType = "cloze";
+export interface ClozePrompt extends JsonMap {
+  type: typeof clozePromptType;
+  block: mdast.BlockContent & JsonMap; // Except note that PhrasingContent can include type ClozePromptNode.
+}
+
+export const qaPromptType = "qaPrompt";
+export interface QAPrompt extends JsonMap {
+  type: typeof qaPromptType;
+  question: mdast.Parent & JsonMap;
+  answer: mdast.Parent & JsonMap;
+}
+
+export type Prompt = ClozePrompt | QAPrompt;
+
+const backlinksNodeType = "backlinksNode";
+
+export const clozeNodeType = "incremental-thinking-cloze";
+export interface ClozePromptNode extends unist.Node {
+  type: typeof clozeNodeType;
+  children: mdast.PhrasingContent[];
+}
+
+export const qaPromptNodeType = "incremental-thinking-QA";
+export interface QAPromptNode extends unist.Node {
+  type: typeof qaPromptNodeType;
+  question: mdast.Parent;
+  answer: mdast.Parent;
+}
+
+type NodeWithParent = unist.Node & {
+  parent?: NodeWithParent;
+};
+
+export const markdownProcessor = unified()
+  .use(remarkParse as any)
+  // @ts-ignore
+  .use(remarkStringify, {
+    bullet: "*",
+    emphasis: "*",
+    listItemIndent: "one",
+    rule: "-",
+    ruleSpaces: false,
+  });
+
+export const processor = markdownProcessor()
+  .use(noteLinkProcessorPlugin)
+  .use(backlinksPlugin)
+  .use(bearIDPlugin)
+  .use(clozePromptPlugin)
+  .use(qaPromptPlugin);
+
+export async function parseMarkdown(content: string) {
+  const root = await processor.run(processor.parse(content));
+  return root as mdast.Root;
+}
+
+export function findAllPrompts(tree: unist.Node): Prompt[] {
+  const treeWithParents = parents(tree) as NodeWithParent;
+  const clozeNodes = unistUtilSelect.selectAll(
+    clozeNodeType,
+    treeWithParents,
+  ) as NodeWithParent[];
+
+  const clozePrompts: ClozePrompt[] = [];
+  const visitedClozePromptBlocks: Set<mdast.BlockContent> = new Set();
+  for (const node of clozeNodes) {
+    let parent = node.parent;
+    while (parent && !isBlockContent(parent)) {
+      parent = parent.parent;
+    }
+
+    if (
+      parent &&
+      !promptNodeHasUnsupportedParent(node) &&
+      !visitedClozePromptBlocks.has(parent)
+    ) {
+      visitedClozePromptBlocks.add(parent);
+      clozePrompts.push({
+        type: "cloze",
+        block: parent as mdast.BlockContent & JsonMap,
+      });
+    }
+  }
+
+  const qaPrompts = unistUtilSelect
+    .selectAll(qaPromptNodeType, treeWithParents)
+    .filter((n) => !promptNodeHasUnsupportedParent(n))
+    .map((n) => {
+      const qaPromptNode = n as QAPromptNode;
+      const qaPrompt: QAPrompt = {
+        type: "qaPrompt",
+        question: qaPromptNode.question as mdast.Parent & JsonMap,
+        answer: qaPromptNode.answer as mdast.Parent & JsonMap,
+      };
+      return qaPrompt;
+    });
+
+  return (clozePrompts as Prompt[]).concat(qaPrompts);
+}
+
+function promptNodeHasUnsupportedParent(promptNode: unist.Node): boolean {
+  let node = (promptNode as NodeWithParent).parent;
+  while (node) {
+    if (node.type === backlinksNodeType) {
+      return true;
+    }
+    node = node.parent;
+  }
+  return false;
+}
+
+const blockTypes = new Set([
+  "paragraph",
+  "heading",
+  "thematicBreak",
+  "blockquote",
+  "list",
+  "table",
+  "html",
+  "code",
+]);
+
+function isBlockContent(node: unist.Node): node is mdast.BlockContent {
+  return blockTypes.has(node.type);
+}

--- a/packages/interpreter/src/interpreters/bear/plugins/backlinksPlugin.test.ts
+++ b/packages/interpreter/src/interpreters/bear/plugins/backlinksPlugin.test.ts
@@ -1,0 +1,102 @@
+import mdast from "mdast";
+import { select } from "unist-util-select";
+import backlinksPlugin, {
+  BacklinksNode,
+  backlinksNodeType,
+} from "./backlinksPlugin";
+import noteLinkProcessorPlugin from "./noteLinkProcessorPlugin";
+import { markdownProcessor } from "../markdown";
+
+const processor = markdownProcessor()
+  .use(noteLinkProcessorPlugin)
+  .use(backlinksPlugin);
+
+function getBacklinksNode(input: string): {
+  backlinksNode: BacklinksNode | null;
+  ast: mdast.Root;
+} {
+  const ast = processor.runSync(processor.parse(input)) as mdast.Root;
+  return {
+    backlinksNode: select(backlinksNodeType, ast) as BacklinksNode | null,
+    ast,
+  };
+}
+
+describe("parses backlink blocks", () => {
+  test("no excerpts", () => {
+    const input = `# Note title
+    
+A paragraph
+
+## Backlinks
+
+* [[Source node]]
+`;
+    const { backlinksNode } = getBacklinksNode(input);
+    expect(backlinksNode!.children).toHaveLength(1);
+    const backlinkSourceNode = backlinksNode!.children[0];
+    expect(backlinkSourceNode.sourceNodeLink.targetNoteName).toEqual(
+      "Source node",
+    );
+    expect(backlinkSourceNode.children).toHaveLength(0);
+  });
+
+  test("with excerpts", () => {
+    const input = `# Note title
+    
+A paragraph
+
+## Backlinks
+
+* [[Source node]]
+\t* This is an excerpt from the source node.
+\t* Another excerpt
+* [[Another source node]]
+
+## Another section
+`;
+    const { backlinksNode, ast } = getBacklinksNode(input);
+    expect(backlinksNode!.children).toHaveLength(2);
+    const firstSourceNode = backlinksNode!.children[0];
+    expect(firstSourceNode.sourceNodeLink.targetNoteName).toEqual(
+      "Source node",
+    );
+    expect(firstSourceNode.children).toHaveLength(2);
+    expect(
+      processor.stringify(firstSourceNode.children[0]).trimRight(),
+    ).toEqual("This is an excerpt from the source node.");
+    expect(
+      processor.stringify(firstSourceNode.children[1]).trimRight(),
+    ).toEqual("Another excerpt");
+    expect(backlinksNode!.children[1].sourceNodeLink.targetNoteName).toEqual(
+      "Another source node",
+    );
+
+    const subsequentHeadingNode = select(
+      "heading[depth=2] *[value='Another section']",
+      ast,
+    );
+    expect(subsequentHeadingNode).toBeTruthy();
+  });
+
+  test("with tag comment", () => {
+    const input = `# Note title
+
+## Backlinks
+
+* [[Source node]]
+
+<!-- #tag -->
+`;
+    const { backlinksNode, ast } = getBacklinksNode(input);
+    expect(backlinksNode!.children).toHaveLength(1);
+    const backlinkSourceNode = backlinksNode!.children[0];
+    expect(backlinkSourceNode.sourceNodeLink.targetNoteName).toEqual(
+      "Source node",
+    );
+    expect(backlinkSourceNode.children).toHaveLength(0);
+
+    const subsequentHeadingNode = select("html", ast);
+    expect(subsequentHeadingNode).toBeTruthy();
+  });
+});

--- a/packages/interpreter/src/interpreters/bear/plugins/backlinksPlugin.ts
+++ b/packages/interpreter/src/interpreters/bear/plugins/backlinksPlugin.ts
@@ -91,6 +91,7 @@ Inside backlinks node: ${JSON.stringify(listItem, null, "\t")}`,
 
 function extractBacklinksBlock(node: mdast.Root | mdast.Content): unist.Node {
   headingRange(
+    // @ts-expect-error
     node,
     "Backlinks",
     (start, nodes, end, { parent, start: startIndex, end: endIndex }) => {

--- a/packages/interpreter/src/interpreters/bear/plugins/backlinksPlugin.ts
+++ b/packages/interpreter/src/interpreters/bear/plugins/backlinksPlugin.ts
@@ -1,0 +1,145 @@
+import unist from "unist";
+import mdast from "mdast";
+import unified from "unified";
+import { headingRange } from "mdast-util-heading-range";
+import * as unistUtilSelect from "unist-util-select";
+import { NoteLinkNode, noteLinkNodeType } from "./noteLinkProcessorPlugin";
+
+export const backlinksNodeType = "backlinksNode";
+
+export interface BacklinksNode extends unist.Parent {
+  type: typeof backlinksNodeType;
+  children: BacklinkSourceNode[];
+}
+
+interface BacklinkSourceNode extends unist.Parent {
+  type: "backlinkSourceNode";
+  sourceNodeLink: NoteLinkNode;
+  children: mdast.BlockContent[]; // excerpts
+}
+
+export default function backlinksPlugin(this: unified.Processor) {
+  // TODO implement compiler
+  return extractBacklinksBlock;
+}
+
+function getBacklinkSourceNodes(listNode: mdast.List): BacklinkSourceNode[] {
+  return listNode.children.map((listItem) => {
+    const sourceReference = listItem.children[0] as mdast.Paragraph;
+    if (!sourceReference || sourceReference.type !== "paragraph") {
+      throw new Error(
+        `Unexpected backlinks source node: ${JSON.stringify(
+          sourceReference,
+        )} ${JSON.stringify(listItem)}`,
+      );
+    }
+    const sourceNodeLink = unistUtilSelect.select(
+      noteLinkNodeType,
+      sourceReference,
+    ) as NoteLinkNode;
+    if (!sourceNodeLink) {
+      throw new Error(
+        `Couldn't find source node link ${JSON.stringify(
+          sourceReference,
+        )} ${JSON.stringify(listItem)}`,
+      );
+    }
+    const excerptList = listItem.children[1] as mdast.List | undefined;
+    if (excerptList && excerptList.type !== "list") {
+      throw new Error(
+        `Unexpected backlinks excerpt list node: ${JSON.stringify(
+          excerptList,
+        )} ${JSON.stringify(listItem)}`,
+      );
+    }
+    const excerpts: mdast.BlockContent[] = excerptList
+      ? excerptList.children.map((excerptListItem) => {
+          if (excerptListItem.type !== "listItem") {
+            throw new Error(
+              `Unexpected backlinks excerpt list item: ${JSON.stringify(
+                excerptListItem,
+                null,
+                "\t",
+              )}
+              
+Inside backlinks node: ${JSON.stringify(listItem, null, "\t")}`,
+            );
+          }
+          if (excerptListItem.children.length > 1) {
+            throw new Error(
+              `Backlinks excerpt list item has too many children: ${JSON.stringify(
+                excerptListItem,
+                null,
+                "\t",
+              )}
+              
+Inside backlinks node: ${JSON.stringify(listItem, null, "\t")}`,
+            );
+          }
+          return excerptListItem.children[0] as mdast.BlockContent;
+        })
+      : [];
+
+    const backlinkSourceNode: BacklinkSourceNode = {
+      type: "backlinkSourceNode",
+      sourceNodeLink,
+      children: excerpts,
+    };
+    return backlinkSourceNode;
+  });
+}
+
+function extractBacklinksBlock(node: mdast.Root | mdast.Content): unist.Node {
+  headingRange(
+    node,
+    "Backlinks",
+    (start, nodes, end, { parent, start: startIndex, end: endIndex }) => {
+      if (!parent) {
+        return nodes;
+      }
+
+      const listNode = nodes[0] as mdast.List;
+      const defaultResult = parent.children.slice(
+        startIndex,
+        endIndex ?? undefined,
+      );
+      if (!listNode || listNode.type !== "list") {
+        console.warn(`Unexpected node in backlinks node:`, listNode);
+        return defaultResult;
+      }
+
+      const remainingNodes = nodes.slice(1);
+
+      // TODO extract Bear comment node parser
+      const nonCommentNodes = remainingNodes.filter(
+        (n) => n.type !== "html" || !(n as mdast.HTML).value.startsWith("<!--"),
+      );
+      if (nonCommentNodes.length > 0) {
+        console.warn(
+          `Unexpected nodes in backlinks node: ${JSON.stringify(
+            nonCommentNodes,
+            null,
+            "\t",
+          )}`,
+        );
+        return defaultResult;
+      }
+
+      try {
+        const sourceNodes = getBacklinkSourceNodes(listNode);
+        return [
+          {
+            type: backlinksNodeType,
+            children: sourceNodes,
+          } as BacklinksNode,
+          ...remainingNodes,
+          ...(end ? [end] : []),
+        ];
+      } catch (error) {
+        console.warn(error);
+        return defaultResult;
+      }
+    },
+  );
+  return node;
+}

--- a/packages/interpreter/src/interpreters/bear/plugins/bearIDPlugin.test.ts
+++ b/packages/interpreter/src/interpreters/bear/plugins/bearIDPlugin.test.ts
@@ -1,0 +1,26 @@
+import mdast from "mdast";
+import remarkParse from "remark-parse";
+import remarkStringify from "remark-stringify";
+import { unified } from "unified";
+import bearIDPlugin, { bearIDNodeType } from "./bearIDPlugin";
+
+const processor = unified()
+  .use(remarkParse)
+  .use(remarkStringify)
+  .use(bearIDPlugin);
+const testBearID = "860466DE-8254-47C1-AA71-BA9C0CE18FA3-402-00002ED1CDC440DA";
+const input = `# Test node
+
+<!-- {BearID:${testBearID}} -->`;
+
+test("decodes IDs", () => {
+  const ast = processor.runSync(processor.parse(input));
+  expect((ast as mdast.Root).children).toContainEqual({
+    type: bearIDNodeType,
+    bearID: testBearID,
+  });
+});
+
+test("encodes IDs", () => {
+  expect(processor.processSync(input).toString().trimRight()).toEqual(input);
+});

--- a/packages/interpreter/src/interpreters/bear/plugins/bearIDPlugin.ts
+++ b/packages/interpreter/src/interpreters/bear/plugins/bearIDPlugin.ts
@@ -1,0 +1,44 @@
+import mdast from "mdast";
+import unified from "unified";
+import unist from "unist";
+import { map as unistUtilMap } from "unist-util-map";
+
+export const bearIDNodeType = "bearID";
+
+export interface BearIDNode extends unist.Node {
+  type: typeof bearIDNodeType;
+  bearID: string;
+}
+
+const bearIDRegexp = /<!-- {BearID:([0-9A-F\-]+?)} -->/;
+
+function reifyBearIDNodes(root: unist.Node): unist.Node {
+  return unistUtilMap(root, (visitee) => {
+    if (visitee.type === "html") {
+      const htmlNode = visitee as mdast.HTML;
+      const match = htmlNode.value.match(bearIDRegexp);
+      if (match) {
+        const bearIDNode: BearIDNode = {
+          type: bearIDNodeType,
+          bearID: match[1],
+        };
+        return bearIDNode;
+      }
+    }
+    return visitee;
+  });
+}
+
+export default function bearIDPlugin(this: unified.Processor) {
+  const data = this.data();
+  if (!data.toMarkdownExtensions) {
+    data.toMarkdownExtensions = [];
+  }
+  (data.toMarkdownExtensions as any[]).push({
+    handlers: {
+      [bearIDNodeType]: (node: BearIDNode) =>
+        `<!-- {BearID:${node.bearID}} -->`,
+    },
+  });
+  return reifyBearIDNodes;
+}

--- a/packages/interpreter/src/interpreters/bear/plugins/clozePromptPlugin.test.ts
+++ b/packages/interpreter/src/interpreters/bear/plugins/clozePromptPlugin.test.ts
@@ -1,0 +1,74 @@
+import remarkParse from "remark-parse";
+import remarkStringify from "remark-stringify";
+import { unified } from "unified";
+import { clozeNodeType } from "../markdown";
+import promptProcessorPlugin from "./clozePromptPlugin";
+
+const processor = unified()
+  .use(remarkParse)
+  .use(remarkStringify)
+  .use(promptProcessorPlugin);
+
+test("parses cloze", () => {
+  const markdown = "This is {a test} of cloze";
+  const ast = processor.parse(markdown);
+  expect(ast).toMatchObject({
+    children: [
+      {
+        type: "paragraph",
+        children: [
+          { type: "text", value: "This is " },
+          {
+            type: clozeNodeType,
+            children: [{ type: "text", value: "a test" }],
+          },
+          { type: "text", value: " of cloze" },
+        ],
+      },
+    ],
+  });
+  expect(processor.stringify(ast).trimRight()).toEqual(markdown);
+});
+
+test("parses cloze at end of line", () => {
+  const markdown = "This is {a test}";
+  const ast = processor.parse(markdown);
+  expect(processor.stringify(ast).trimRight()).toEqual(markdown);
+});
+
+test("doesn't parse unbalanced braces", () => {
+  const markdown = "This is {a test of cloze";
+  const ast = processor.parse(markdown);
+  expect(ast).toMatchObject({
+    children: [
+      {
+        type: "paragraph",
+        children: [{ type: "text", value: markdown }],
+      },
+    ],
+  });
+
+  expect(processor.stringify(ast).trimRight()).toEqual(markdown);
+});
+
+test("parses nested braces", () => {
+  const markdown = "This is {a {test}} of cloze";
+  const ast = processor.parse(markdown);
+  expect(ast).toMatchObject({
+    children: [
+      {
+        type: "paragraph",
+        children: [
+          { type: "text", value: "This is " },
+          {
+            type: clozeNodeType,
+            children: [{ type: "text", value: "a {test}" }],
+          },
+          { type: "text", value: " of cloze" },
+        ],
+      },
+    ],
+  });
+
+  expect(processor.stringify(ast).trimRight()).toEqual(markdown);
+});

--- a/packages/interpreter/src/interpreters/bear/plugins/clozePromptPlugin.ts
+++ b/packages/interpreter/src/interpreters/bear/plugins/clozePromptPlugin.ts
@@ -1,0 +1,121 @@
+import * as Mdast from "mdast-util-from-markdown";
+import { markdownLineEnding } from "micromark-util-character";
+import { codes } from "micromark-util-symbol/codes.js";
+import * as Micromark from "micromark-util-types";
+import { Processor } from "unified";
+import { processor } from "../markdown";
+import { clozeNodeType, ClozePromptNode } from "../markdown";
+
+// TODO: don't match clozes inside code and html blocks
+const clozeToken = "clozePrompt";
+const clozeMarkerToken = "clozePromptMarker";
+const clozeChunkToken = "clozePromptChunk";
+
+const micromarkClozeExtension: Micromark.Extension = {
+  text: { [codes.leftCurlyBrace]: { tokenize } },
+};
+
+function tokenize(
+  this: Micromark.TokenizeContext,
+  effects: Micromark.Effects,
+  ok: Micromark.State,
+  nok: Micromark.State,
+) {
+  let balance = 1;
+
+  return atOpeningBrace;
+
+  function atOpeningBrace(code: Micromark.Code): Micromark.State {
+    effects.enter(clozeToken);
+    effects.enter(clozeMarkerToken);
+    effects.consume(code);
+    effects.exit(clozeMarkerToken);
+
+    effects.enter(clozeChunkToken);
+    return inside;
+  }
+
+  function inside(code: Micromark.Code): Micromark.State {
+    if (code === codes.eof || markdownLineEnding(code)) {
+      return nok;
+    } else if (code === codes.rightCurlyBrace) {
+      effects.exit(clozeChunkToken);
+      return atClosingBrace(code);
+    } else if (code === codes.leftCurlyBrace) {
+      effects.consume(code);
+      balance++;
+      return inside;
+    } else {
+      effects.consume(code);
+      return inside;
+    }
+  }
+
+  function atClosingBrace(code: Micromark.Code): Micromark.State {
+    balance--;
+    if (balance) {
+      effects.enter(clozeChunkToken);
+      effects.consume(code);
+      return inside;
+    } else {
+      effects.enter(clozeMarkerToken);
+      effects.consume(code);
+      effects.exit(clozeMarkerToken);
+      effects.exit(clozeToken);
+      return ok;
+    }
+  }
+}
+
+export default function clozePlugin(this: Processor) {
+  const data = this.data();
+
+  if (!data.toMarkdownExtensions) {
+    data.toMarkdownExtensions = [];
+  }
+  (data.toMarkdownExtensions as any[]).push({
+    handlers: {
+      [clozeNodeType]: clozePromptCompiler,
+    },
+  });
+
+  if (!data.micromarkExtensions) {
+    data.micromarkExtensions = [];
+  }
+  (data.micromarkExtensions as any[]).push(micromarkClozeExtension);
+
+  if (!data.fromMarkdownExtensions) {
+    data.fromMarkdownExtensions = [];
+  }
+  (data.fromMarkdownExtensions as any[]).push({
+    enter: {
+      [clozeToken]: enterClozeNode,
+      [clozeChunkToken]: enterClozeNodeData,
+    },
+    exit: {
+      [clozeToken]: exitClozeNode,
+      [clozeChunkToken]: exitClozeNodeData,
+    },
+  });
+}
+
+function enterClozeNode(this: Mdast.CompileContext, token: Mdast.Token) {
+  this.enter({ type: clozeNodeType, children: [] } as any, token);
+}
+
+function exitClozeNode(this: Mdast.CompileContext, token: Mdast.Token) {
+  this.exit(token);
+}
+
+function enterClozeNodeData(this: Mdast.CompileContext, token: Mdast.Token) {
+  this.config.enter.data.call(this, token);
+}
+
+function exitClozeNodeData(this: Mdast.CompileContext, token: Mdast.Token) {
+  this.config.exit.data.call(this, token);
+}
+
+function clozePromptCompiler(node: ClozePromptNode): string {
+  const result = processor.stringify({ ...node, type: "emphasis" }) as string;
+  return `{${result.slice(1, -2)}}`;
+}

--- a/packages/interpreter/src/interpreters/bear/plugins/noteLinkProcessorPlugin.ts
+++ b/packages/interpreter/src/interpreters/bear/plugins/noteLinkProcessorPlugin.ts
@@ -1,0 +1,48 @@
+// @ts-ignore
+import remarkWikiLink from "remark-wiki-link";
+import unified from "unified";
+import unist from "unist";
+import { map as unistUtilMap } from "unist-util-map";
+
+export const noteLinkNodeType = "noteLinkNode";
+export interface NoteLinkNode extends unist.Node {
+  type: typeof noteLinkNodeType;
+  targetNoteName: string;
+  targetNoteDisplayName: string;
+}
+
+function transformWikiLinksIntoNoteLinks(node: unist.Node): unist.Node {
+  return unistUtilMap(node, (visitee) => {
+    if (visitee.type === "wikiLink") {
+      const wikiLinkNode =
+        visitee as unknown as remarkWikiLink.RemarkWikiLinkNode;
+      return {
+        type: "noteLinkNode",
+        targetNoteName: wikiLinkNode.value,
+        targetNoteDisplayName: wikiLinkNode.data.alias,
+      } as NoteLinkNode;
+    } else {
+      return visitee;
+    }
+  });
+}
+
+export default function noteLinkPlugin(this: unified.Processor) {
+  // A bit of a hack. remark-wiki-link is a parser; this plugin adds a transformer on the end. A client could reasonably expect to be able to simply run `parse` and get a result with the node links. Instead, they have to run `run`, since the transformers also need to be executed. Should fix that. TODO
+  remarkWikiLink.apply(this);
+
+  const data = this.data();
+  if (!data.toMarkdownExtensions) {
+    data.toMarkdownExtensions = [];
+  }
+  (data.toMarkdownExtensions as any[]).push({
+    handlers: {
+      noteLinkNode: (node: NoteLinkNode) =>
+        node.targetNoteName === node.targetNoteDisplayName
+          ? `[[${node.targetNoteName}]]`
+          : `[[${node.targetNoteName}:${node.targetNoteDisplayName}]]`,
+    },
+  });
+
+  return transformWikiLinksIntoNoteLinks;
+}

--- a/packages/interpreter/src/interpreters/bear/plugins/qaPromptPlugin.test.ts
+++ b/packages/interpreter/src/interpreters/bear/plugins/qaPromptPlugin.test.ts
@@ -1,0 +1,85 @@
+import { select, selectAll } from "unist-util-select";
+import { markdownProcessor } from "../markdown";
+import { QAPromptNode, qaPromptNodeType } from "../markdown";
+import qaPromptPlugin from "./qaPromptPlugin";
+
+const processor = markdownProcessor.use(qaPromptPlugin);
+
+describe("extracts QA prompts", () => {
+  test("two paragraphs", () => {
+    const input = `Some other text
+    
+Q. A question prompt
+
+A. An answer prompt
+
+Some more text`;
+    const ast = processor.runSync(processor.parse(input));
+    const qaPromptNode = select(qaPromptNodeType, ast)! as QAPromptNode;
+    expect(qaPromptNode).toBeTruthy();
+
+    expect(processor.stringify(qaPromptNode.question).trimRight()).toEqual(
+      "A question prompt",
+    );
+    expect(processor.stringify(qaPromptNode.answer).trimRight()).toEqual(
+      "An answer prompt",
+    );
+  });
+
+  test("single paragraph", () => {
+    const input = `Some other text
+    
+Q. A question *prompt*
+A. An answer prompt
+
+Some more text`;
+    const ast = processor.runSync(processor.parse(input));
+    const qaPromptNode = select(qaPromptNodeType, ast)! as QAPromptNode;
+    expect(qaPromptNode).toBeTruthy();
+
+    expect(processor.stringify(qaPromptNode.question).trimRight()).toEqual(
+      "A question *prompt*",
+    );
+    expect(processor.stringify(qaPromptNode.answer).trimRight()).toEqual(
+      "An answer prompt",
+    );
+  });
+
+  test("single line", () => {
+    const input = `Some other text
+    
+Q. A question *prompt*. A. An answer prompt
+
+Some more text`;
+    const ast = processor.runSync(processor.parse(input));
+    const qaPromptNode = select(qaPromptNodeType, ast)! as QAPromptNode;
+    expect(qaPromptNode).toBeNull();
+  });
+
+  test("fake QA prompt", () => {
+    const input = `Some other text
+    
+A. An answer prompt
+
+Some more text`;
+    const ast = processor.runSync(processor.parse(input));
+    const qaPromptNode = select(qaPromptNodeType, ast)! as QAPromptNode;
+    expect(qaPromptNode).toBeNull();
+  });
+
+  test("multiple prompts", () => {
+    const input = `Some other text
+    
+Q. A question prompt
+
+A. An answer
+
+Q. Another question prompt
+
+A. Another answer
+
+Some more text`;
+    const ast = processor.runSync(processor.parse(input));
+    expect(selectAll(qaPromptNodeType, ast)).toHaveLength(2);
+  });
+});

--- a/packages/interpreter/src/interpreters/bear/plugins/qaPromptPlugin.ts
+++ b/packages/interpreter/src/interpreters/bear/plugins/qaPromptPlugin.ts
@@ -1,0 +1,132 @@
+import mdast from "mdast";
+import unified from "unified";
+import unist from "unist";
+import { parents } from "unist-util-parents";
+import * as unistUtilSelect from "unist-util-select";
+import { QAPromptNode, qaPromptNodeType } from "../markdown";
+
+// TODO: don't match QA prompts inside coxde and html blocks
+export default function qaPromptPlugin(this: unified.Processor) {
+  return extractQAPromptNodes;
+}
+
+const questionPrefix = "Q. ";
+const answerPrefix = "A. ";
+const answerSplitRegexp = new RegExp(`\n${answerPrefix}`, "m");
+
+type NodeWithParent<N extends unist.Node = unist.Node> = unist.Node & {
+  parent?: NodeWithParent<unist.Parent>;
+  node: N;
+};
+
+function extractQAPromptNodes(node: unist.Node): unist.Node {
+  const nodeWithParents = parents(node);
+  const answerNodes = unistUtilSelect.selectAll(
+    `paragraph>text[value^='${answerPrefix}']`,
+    nodeWithParents,
+  ) as NodeWithParent[];
+  for (const answerNode of answerNodes) {
+    const parent = answerNode.parent!.parent!.node;
+    const answerParagraphIndex = parent.children.indexOf(
+      answerNode.parent!.node,
+    );
+    if (answerParagraphIndex === -1 || answerParagraphIndex === 0) {
+      throw new Error(
+        `Unexpected QA prompt answer node: ${JSON.stringify(
+          answerNode,
+          null,
+          "\t",
+        )}`,
+      );
+    }
+    const questionParagraphNode = parent.children[
+      answerParagraphIndex - 1
+    ] as mdast.Paragraph;
+    if (questionParagraphNode.type === "paragraph") {
+      const questionTextNode = questionParagraphNode.children[0] as mdast.Text;
+      if (
+        questionParagraphNode.children.length === 1 &&
+        questionTextNode.type === "text"
+      ) {
+        if (questionTextNode.value.startsWith(questionPrefix)) {
+          // Now we'll strip the prefixes off.
+          const answerParagraphNode = parent.children[
+            answerParagraphIndex
+          ] as mdast.Paragraph;
+          questionTextNode.value = questionTextNode.value.slice(
+            questionPrefix.length,
+          );
+          const answerTextNode = answerParagraphNode.children[0] as mdast.Text;
+          answerTextNode.value = answerTextNode.value.slice(
+            answerPrefix.length,
+          );
+
+          const qaPromptNode: QAPromptNode = {
+            type: qaPromptNodeType,
+            question: questionParagraphNode,
+            answer: answerParagraphNode,
+          };
+          parent.children.splice(answerParagraphIndex - 1, 2, qaPromptNode);
+        }
+      }
+    }
+  }
+
+  const questionNodes = unistUtilSelect.selectAll(
+    `paragraph>text[value^='${questionPrefix}']`,
+    nodeWithParents,
+  ) as NodeWithParent[];
+  for (const questionNode of questionNodes) {
+    const paragraphNode = questionNode.parent!.node as mdast.Paragraph;
+    const splitNodeIndex = paragraphNode.children.findIndex(
+      (node) =>
+        node.type === "text" &&
+        answerSplitRegexp.test((node as mdast.Text).value),
+    );
+    if (splitNodeIndex === -1) {
+      continue;
+    }
+
+    const splitNode = paragraphNode.children[splitNodeIndex] as mdast.Text;
+    const match = splitNode.value.match(answerSplitRegexp)!;
+    const preSplitString = splitNode.value.slice(0, match.index!);
+    const postSplitString = splitNode.value.slice(match.index!);
+
+    const questionPhrasingNodes = paragraphNode.children.slice(
+      0,
+      splitNodeIndex,
+    );
+    const answerPhrasingNodes = paragraphNode.children.slice(splitNodeIndex);
+    if (preSplitString !== "" && answerPhrasingNodes[0].type === "text") {
+      // We've gotta split that node.
+      questionPhrasingNodes.push({
+        type: "text",
+        value: preSplitString,
+      });
+      answerPhrasingNodes[0].value = postSplitString;
+    }
+    (questionPhrasingNodes[0] as mdast.Text).value = (
+      questionPhrasingNodes[0] as mdast.Text
+    ).value.slice(questionPrefix.length);
+    (answerPhrasingNodes[0] as mdast.Text).value = (
+      answerPhrasingNodes[0] as mdast.Text
+    ).value.slice(
+      answerPrefix.length + 1, // add 1 for the newline
+    );
+
+    const qaPromptNode: QAPromptNode = {
+      type: qaPromptNodeType,
+      question: { type: "paragraph", children: questionPhrasingNodes },
+      answer: { type: "paragraph", children: answerPhrasingNodes },
+    };
+    const paragraphContainer = questionNode.parent!.parent!
+      .node as unist.Parent;
+    paragraphContainer.children.splice(
+      paragraphContainer.children.indexOf(paragraphNode),
+      1,
+      qaPromptNode,
+    );
+  }
+
+  return node;
+}

--- a/packages/interpreter/src/interpreters/bear/utils/getNoteTitle.test.ts
+++ b/packages/interpreter/src/interpreters/bear/utils/getNoteTitle.test.ts
@@ -1,0 +1,26 @@
+import mdast from "mdast";
+import { processor } from "../markdown";
+import { getNoteTitle } from "./getNoteTitle";
+
+describe("getting note title", () => {
+  test("extracts title heading", () => {
+    const input = `# Test node
+    
+Another paragraph`;
+    const tree = processor.runSync(processor.parse(input)) as mdast.Root;
+    expect(getNoteTitle(tree)).toEqual("Test node");
+  });
+
+  test("extracts title non-heading", () => {
+    const input = `Non-heading title
+    
+More text`;
+    const tree = processor.runSync(processor.parse(input)) as mdast.Root;
+    expect(getNoteTitle(tree)).toEqual("Non-heading title");
+  });
+
+  test("doesn't extract non-title", () => {
+    const tree = processor.runSync(processor.parse("")) as mdast.Root;
+    expect(getNoteTitle(tree)).toBeNull();
+  });
+});

--- a/packages/interpreter/src/interpreters/bear/utils/getNoteTitle.ts
+++ b/packages/interpreter/src/interpreters/bear/utils/getNoteTitle.ts
@@ -6,22 +6,14 @@ export function getNoteTitle(noteRoot: mdast.Root): string | null {
   if (noteRoot.children.length > 0) {
     const firstNode = noteRoot.children[0];
     if (firstNode.type === "heading") {
-      return (
-        processor
-          .stringify({
-            type: "paragraph",
-            children: firstNode.children,
-          } as unist.Node)
-          // @ts-expect-error typings are wrong for this function
-          .trimRight()
-      );
+      return processor
+        .stringify({
+          type: "paragraph",
+          children: firstNode.children,
+        } as unist.Node)
+        .trimRight();
     } else {
-      return (
-        processor
-          .stringify(firstNode)
-          // @ts-expect-error typings are wrong for this function
-          .trimRight()
-      );
+      return processor.stringify(firstNode).trimRight();
     }
   } else {
     return null;

--- a/packages/interpreter/src/interpreters/bear/utils/getNoteTitle.ts
+++ b/packages/interpreter/src/interpreters/bear/utils/getNoteTitle.ts
@@ -1,0 +1,29 @@
+import unist from "unist";
+import mdast from "mdast";
+import { processor } from "../markdown";
+
+export function getNoteTitle(noteRoot: mdast.Root): string | null {
+  if (noteRoot.children.length > 0) {
+    const firstNode = noteRoot.children[0];
+    if (firstNode.type === "heading") {
+      return (
+        processor
+          .stringify({
+            type: "paragraph",
+            children: firstNode.children,
+          } as unist.Node)
+          // @ts-expect-error typings are wrong for this function
+          .trimRight()
+      );
+    } else {
+      return (
+        processor
+          .stringify(firstNode)
+          // @ts-expect-error typings are wrong for this function
+          .trimRight()
+      );
+    }
+  } else {
+    return null;
+  }
+}

--- a/packages/interpreter/src/interpreters/bear/utils/getStableBearID.test.ts
+++ b/packages/interpreter/src/interpreters/bear/utils/getStableBearID.test.ts
@@ -1,0 +1,23 @@
+import mdast from "mdast";
+import { processor } from "../markdown";
+import { getStableBearID } from "./getStableBearID";
+
+describe("finding note IDs", () => {
+  describe("bear note IDs", () => {
+    test("extracts bear note ID", () => {
+      const testBearID =
+        "860466DE-8254-47C1-AA71-BA9C0CE18FA3-402-00002ED1CDC440DA";
+      const input = `# Test node
+
+<!-- {BearID:${testBearID}} -->`;
+
+      const tree = processor.runSync(processor.parse(input)) as mdast.Root;
+      const noteID = getStableBearID(tree);
+      expect(noteID).toBeTruthy();
+      expect(noteID!.id).toEqual(testBearID);
+      expect(noteID!.openURL).toMatchInlineSnapshot(
+        `"bear://x-callback-url/open-note?id=860466DE-8254-47C1-AA71-BA9C0CE18FA3-402-00002ED1CDC440DA"`,
+      );
+    });
+  });
+});

--- a/packages/interpreter/src/interpreters/bear/utils/getStableBearID.ts
+++ b/packages/interpreter/src/interpreters/bear/utils/getStableBearID.ts
@@ -9,7 +9,6 @@ function getOpenURLForBearID(bearID: string): string {
 export type BearID = { id: string; openURL: string };
 export function getStableBearID(noteRoot: mdast.Root): BearID | null {
   const bearNoteIDNodes = unistUtilSelect.selectAll(bearIDNodeType, noteRoot);
-
   if (bearNoteIDNodes.length === 1) {
     const bearID = (bearNoteIDNodes[0] as BearIDNode).bearID;
     return { id: bearID, openURL: getOpenURLForBearID(bearID) };

--- a/packages/interpreter/src/interpreters/bear/utils/getStableBearID.ts
+++ b/packages/interpreter/src/interpreters/bear/utils/getStableBearID.ts
@@ -1,0 +1,22 @@
+import mdast from "mdast";
+import * as unistUtilSelect from "unist-util-select";
+import { BearIDNode, bearIDNodeType } from "../plugins/bearIDPlugin";
+
+function getOpenURLForBearID(bearID: string): string {
+  return `bear://x-callback-url/open-note?id=${bearID}`;
+}
+
+export type BearID = { id: string; openURL: string };
+export function getStableBearID(noteRoot: mdast.Root): BearID | null {
+  const bearNoteIDNodes = unistUtilSelect.selectAll(bearIDNodeType, noteRoot);
+
+  if (bearNoteIDNodes.length === 1) {
+    const bearID = (bearNoteIDNodes[0] as BearIDNode).bearID;
+    return { id: bearID, openURL: getOpenURLForBearID(bearID) };
+  } else if (bearNoteIDNodes.length > 1) {
+    console.debug("Multiple Bear note IDs in note", noteRoot, bearNoteIDNodes);
+    return null;
+  } else {
+    return null;
+  }
+}

--- a/packages/interpreter/src/interpreters/index.ts
+++ b/packages/interpreter/src/interpreters/index.ts
@@ -1,0 +1,1 @@
+export * from "./bear/BearInterpreter";

--- a/packages/interpreter/tsconfig.json
+++ b/packages/interpreter/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "extends": "../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "types": ["jest", "node"]
+  },
+  "include": ["./src/**/*.ts", "./src/**/*.json"],
+  "references": [
+    {
+      "path": "../core"
+    },
+    {
+      "path": "../store-fs"
+    },
+    {
+      "path": "../ingester"
+    }
+  ]
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -25704,6 +25704,15 @@ remark-mdx@1.6.22:
     remark-parse "8.0.3"
     unified "9.2.0"
 
+remark-parse@10.0.0, remark-parse@^10.0.0:
+  version "10.0.0"
+  resolved "https://registry.yarnpkg.com/remark-parse/-/remark-parse-10.0.0.tgz#65e2b2b34d8581d36b97f12a2926bb2126961cb4"
+  integrity sha512-07ei47p2Xl7Bqbn9H2VYQYirnAFJPwdMuypdozWsSbnmrkgA2e2sZLZdnDNrrsxR4onmIzH/J6KXqKxCuqHtPQ==
+  dependencies:
+    "@types/mdast" "^3.0.0"
+    mdast-util-from-markdown "^1.0.0"
+    unified "^10.0.0"
+
 remark-parse@8.0.3:
   version "8.0.3"
   resolved "https://registry.yarnpkg.com/remark-parse/-/remark-parse-8.0.3.tgz#9c62aa3b35b79a486454c690472906075f40c7e1"
@@ -25726,24 +25735,6 @@ remark-parse@8.0.3:
     vfile-location "^3.0.0"
     xtend "^4.0.1"
 
-remark-parse@^10.0.0:
-  version "10.0.0"
-  resolved "https://registry.yarnpkg.com/remark-parse/-/remark-parse-10.0.0.tgz#65e2b2b34d8581d36b97f12a2926bb2126961cb4"
-  integrity sha512-07ei47p2Xl7Bqbn9H2VYQYirnAFJPwdMuypdozWsSbnmrkgA2e2sZLZdnDNrrsxR4onmIzH/J6KXqKxCuqHtPQ==
-  dependencies:
-    "@types/mdast" "^3.0.0"
-    mdast-util-from-markdown "^1.0.0"
-    unified "^10.0.0"
-
-remark-parse@^10.0.1:
-  version "10.0.1"
-  resolved "https://registry.yarnpkg.com/remark-parse/-/remark-parse-10.0.1.tgz#6f60ae53edbf0cf38ea223fe643db64d112e0775"
-  integrity sha512-1fUyHr2jLsVOkhbvPRBJ5zTKZZyD6yZzYaWCS6BPBdQ8vEMBCH+9zNCDA6tET/zHCi/jLqjCWtlJZUPk+DbnFw==
-  dependencies:
-    "@types/mdast" "^3.0.0"
-    mdast-util-from-markdown "^1.0.0"
-    unified "^10.0.0"
-
 remark-slug@^6.0.0:
   version "6.0.0"
   resolved "https://registry.yarnpkg.com/remark-slug/-/remark-slug-6.0.0.tgz#2b54a14a7b50407a5e462ac2f376022cce263e2c"
@@ -25760,19 +25751,10 @@ remark-squeeze-paragraphs@4.0.0:
   dependencies:
     mdast-squeeze-paragraphs "^4.0.0"
 
-remark-stringify@^10.0.0:
+remark-stringify@10.0.0, remark-stringify@^10.0.0:
   version "10.0.0"
   resolved "https://registry.yarnpkg.com/remark-stringify/-/remark-stringify-10.0.0.tgz#7f23659d92b2d5da489e3c858656d7bbe045f161"
   integrity sha512-3LAQqJ/qiUxkWc7fUcVuB7RtIT38rvmxfmJG8z1TiE/D8zi3JGQ2tTcTJu9Tptdpb7gFwU0whRi5q1FbFOb9yA==
-  dependencies:
-    "@types/mdast" "^3.0.0"
-    mdast-util-to-markdown "^1.0.0"
-    unified "^10.0.0"
-
-remark-stringify@^10.0.2:
-  version "10.0.2"
-  resolved "https://registry.yarnpkg.com/remark-stringify/-/remark-stringify-10.0.2.tgz#50414a6983f5008eb9e72eed05f980582d1f69d7"
-  integrity sha512-6wV3pvbPvHkbNnWB0wdDvVFHOe1hBRAx1Q/5g/EpH4RppAII6J8Gnwe7VbHuXaoKIF6LAg6ExTel/+kNqSQ7lw==
   dependencies:
     "@types/mdast" "^3.0.0"
     mdast-util-to-markdown "^1.0.0"
@@ -28620,19 +28602,7 @@ unified-stream@^2.0.0:
     unified "^10.0.0"
     vfile "^5.0.0"
 
-unified@9.2.0:
-  version "9.2.0"
-  resolved "https://registry.yarnpkg.com/unified/-/unified-9.2.0.tgz#67a62c627c40589edebbf60f53edfd4d822027f8"
-  integrity sha512-vx2Z0vY+a3YoTj8+pttM3tiJHCwY5UFbYdiWrwBEbHmK8pvsPj2rtAX2BFfgXen8T39CJWblWRDT4L5WGXtDdg==
-  dependencies:
-    bail "^1.0.0"
-    extend "^3.0.0"
-    is-buffer "^2.0.0"
-    is-plain-obj "^2.0.0"
-    trough "^1.0.0"
-    vfile "^4.0.0"
-
-unified@^10.0.0, unified@^10.1.0:
+unified@10.1.0, unified@^10.0.0, unified@^10.1.0:
   version "10.1.0"
   resolved "https://registry.yarnpkg.com/unified/-/unified-10.1.0.tgz#4e65eb38fc2448b1c5ee573a472340f52b9346fe"
   integrity sha512-4U3ru/BRXYYhKbwXV6lU6bufLikoAavTwev89H5UxY8enDFaAT2VXmIXYNm6hb5oHPng/EXr77PVyDFcptbk5g==
@@ -28645,18 +28615,17 @@ unified@^10.0.0, unified@^10.1.0:
     trough "^2.0.0"
     vfile "^5.0.0"
 
-unified@^10.1.2:
-  version "10.1.2"
-  resolved "https://registry.yarnpkg.com/unified/-/unified-10.1.2.tgz#b1d64e55dafe1f0b98bb6c719881103ecf6c86df"
-  integrity sha512-pUSWAi/RAnVy1Pif2kAoeWNBa3JVrx0MId2LASj8G+7AiHWoKZNTomq6LG326T68U7/e263X6fTdcXIy7XnF7Q==
+unified@9.2.0:
+  version "9.2.0"
+  resolved "https://registry.yarnpkg.com/unified/-/unified-9.2.0.tgz#67a62c627c40589edebbf60f53edfd4d822027f8"
+  integrity sha512-vx2Z0vY+a3YoTj8+pttM3tiJHCwY5UFbYdiWrwBEbHmK8pvsPj2rtAX2BFfgXen8T39CJWblWRDT4L5WGXtDdg==
   dependencies:
-    "@types/unist" "^2.0.0"
-    bail "^2.0.0"
+    bail "^1.0.0"
     extend "^3.0.0"
     is-buffer "^2.0.0"
-    is-plain-obj "^4.0.0"
-    trough "^2.0.0"
-    vfile "^5.0.0"
+    is-plain-obj "^2.0.0"
+    trough "^1.0.0"
+    vfile "^4.0.0"
 
 unimodules-app-loader@~2.2.0:
   version "2.2.0"
@@ -28744,7 +28713,7 @@ unist-util-is@^5.0.0:
   resolved "https://registry.yarnpkg.com/unist-util-is/-/unist-util-is-5.1.1.tgz#e8aece0b102fa9bc097b0fef8f870c496d4a6236"
   integrity sha512-F5CZ68eYzuSvJjGhCLPL3cYx45IxkqXSetCcRgUXtbcm50X2L9oOWQlfUfDdAf+6Pd27YDblBfdtmsThXmwpbQ==
 
-unist-util-map@^3.0.0:
+unist-util-map@3.0.0, unist-util-map@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/unist-util-map/-/unist-util-map-3.0.0.tgz#ec4c3e4f3f65f559b6c232087af2a470f3e5db89"
   integrity sha512-kyPbOAlOPZpytdyquF1g6qYpAjkpMpSPtR7TAj4SOQWSJfQ/LN+IFI2oWBvkxzhsPKxiMKZcgpp5ihZLLvNl6g==
@@ -28777,22 +28746,11 @@ unist-util-remove@^2.0.0:
   dependencies:
     unist-util-is "^4.0.0"
 
-unist-util-select@^4.0.0:
+unist-util-select@4.0.0, unist-util-select@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/unist-util-select/-/unist-util-select-4.0.0.tgz#8bd8ea171d937a56f56bf849861242a232d37466"
   integrity sha512-UJsER0ubbBy8KR+5zZpcF/9/aApWOzjNqfseMjcw1h0wAUqbxAf56mMewspAqXtGKiwBylnYB+PbD/XqwcYrWg==
   dependencies:
-    css-selector-parser "^1.0.0"
-    nth-check "^2.0.0"
-    unist-util-is "^5.0.0"
-    zwitch "^2.0.0"
-
-unist-util-select@^4.0.1:
-  version "4.0.1"
-  resolved "https://registry.yarnpkg.com/unist-util-select/-/unist-util-select-4.0.1.tgz#d1913d7a0ab4e5d4b6dd1b33b3ea79b9f9645b0b"
-  integrity sha512-zPozyEo5vr1csbHf1TqlQrnuLVJ0tNMo63og3HrnINh2+OIDAgQpqHVr+0BMw1DIVHJV8ft/e6BZqtvD1Y5enw==
-  dependencies:
-    "@types/unist" "^2.0.0"
     css-selector-parser "^1.0.0"
     nth-check "^2.0.0"
     unist-util-is "^5.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -33,6 +33,13 @@
   dependencies:
     "@babel/highlight" "^7.12.13"
 
+"@babel/code-frame@^7.16.7":
+  version "7.16.7"
+  resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.16.7.tgz#44416b6bd7624b998f5b1af5d470856c40138789"
+  integrity sha512-iAXqUn8IIeBTNd72xsFlgaXHkMBMt6y4HJp1tIaK465CWLT/fG1aqB7ykr95gHHmlBdGbFeWWfyB4NJJ0nmeIg==
+  dependencies:
+    "@babel/highlight" "^7.16.7"
+
 "@babel/compat-data@^7.11.0", "@babel/compat-data@^7.12.5":
   version "7.12.5"
   resolved "https://registry.yarnpkg.com/@babel/compat-data/-/compat-data-7.12.5.tgz#f56db0c4bb1bbbf221b4e81345aab4141e7cb0e9"
@@ -47,6 +54,11 @@
   version "7.14.7"
   resolved "https://registry.yarnpkg.com/@babel/compat-data/-/compat-data-7.14.7.tgz#7b047d7a3a89a67d2258dc61f604f098f1bc7e08"
   integrity sha512-nS6dZaISCXJ3+518CWiBfEr//gHyMO02uDxBkXTKZDN5POruCnOZ1N4YBRZDCabwF8nZMWBpRxIicmXtBs+fvw==
+
+"@babel/compat-data@^7.16.8", "@babel/compat-data@^7.17.0", "@babel/compat-data@^7.17.7":
+  version "7.17.7"
+  resolved "https://registry.yarnpkg.com/@babel/compat-data/-/compat-data-7.17.7.tgz#078d8b833fbbcc95286613be8c716cef2b519fa2"
+  integrity sha512-p8pdE6j0a29TNGebNm7NzYZWB3xVZJBZ7XGs42uAKzQo8VQ3F0By/cQCtUEABwIqw5zo6WA4NbmxsfzADzMKnQ==
 
 "@babel/core@7.12.9":
   version "7.12.9"
@@ -192,6 +204,15 @@
     jsesc "^2.5.1"
     source-map "^0.5.0"
 
+"@babel/generator@^7.17.9":
+  version "7.17.9"
+  resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-7.17.9.tgz#f4af9fd38fa8de143c29fce3f71852406fc1e2fc"
+  integrity sha512-rAdDousTwxbIxbz5I7GEQ3lUip+xVCXooZNbsydCWs3xA7ZsYOv+CFRdzGxRX78BmQHu9B1Eso59AOZQOJDEdQ==
+  dependencies:
+    "@babel/types" "^7.17.0"
+    jsesc "^2.5.1"
+    source-map "^0.5.0"
+
 "@babel/generator@^7.5.0":
   version "7.11.6"
   resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-7.11.6.tgz#b868900f81b163b4d464ea24545c61cbac4dc620"
@@ -222,6 +243,13 @@
   dependencies:
     "@babel/types" "^7.14.5"
 
+"@babel/helper-annotate-as-pure@^7.16.7":
+  version "7.16.7"
+  resolved "https://registry.yarnpkg.com/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.16.7.tgz#bb2339a7534a9c128e3102024c60760a3a7f3862"
+  integrity sha512-s6t2w/IPQVTAET1HitoowRGXooX8mCgtuP5195wD/QJPV6wYjpujCGF7JuMODVX2ZAJOf1GT6DT9MHEZvLOFSw==
+  dependencies:
+    "@babel/types" "^7.16.7"
+
 "@babel/helper-builder-binary-assignment-operator-visitor@^7.10.4":
   version "7.10.4"
   resolved "https://registry.yarnpkg.com/@babel/helper-builder-binary-assignment-operator-visitor/-/helper-builder-binary-assignment-operator-visitor-7.10.4.tgz#bb0b75f31bf98cbf9ff143c1ae578b87274ae1a3"
@@ -245,6 +273,14 @@
   dependencies:
     "@babel/helper-explode-assignable-expression" "^7.14.5"
     "@babel/types" "^7.14.5"
+
+"@babel/helper-builder-binary-assignment-operator-visitor@^7.16.7":
+  version "7.16.7"
+  resolved "https://registry.yarnpkg.com/@babel/helper-builder-binary-assignment-operator-visitor/-/helper-builder-binary-assignment-operator-visitor-7.16.7.tgz#38d138561ea207f0f69eb1626a418e4f7e6a580b"
+  integrity sha512-C6FdbRaxYjwVu/geKW4ZeQ0Q31AftgRcdSnZ5/jsH6BzCJbtvXvhpfkbkThYSuutZA7nCXpPR6AD9zd1dprMkA==
+  dependencies:
+    "@babel/helper-explode-assignable-expression" "^7.16.7"
+    "@babel/types" "^7.16.7"
 
 "@babel/helper-builder-react-jsx-experimental@^7.10.4":
   version "7.11.5"
@@ -293,6 +329,16 @@
     browserslist "^4.16.6"
     semver "^6.3.0"
 
+"@babel/helper-compilation-targets@^7.16.7":
+  version "7.17.7"
+  resolved "https://registry.yarnpkg.com/@babel/helper-compilation-targets/-/helper-compilation-targets-7.17.7.tgz#a3c2924f5e5f0379b356d4cfb313d1414dc30e46"
+  integrity sha512-UFzlz2jjd8kroj0hmCFV5zr+tQPi1dpC2cRsDV/3IEW8bJfCPrPpmcSN6ZS8RqIq4LXcmpipCQFPddyFA5Yc7w==
+  dependencies:
+    "@babel/compat-data" "^7.17.7"
+    "@babel/helper-validator-option" "^7.16.7"
+    browserslist "^4.17.5"
+    semver "^6.3.0"
+
 "@babel/helper-create-class-features-plugin@^7.10.4", "@babel/helper-create-class-features-plugin@^7.10.5", "@babel/helper-create-class-features-plugin@^7.12.1":
   version "7.12.1"
   resolved "https://registry.yarnpkg.com/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.12.1.tgz#3c45998f431edd4a9214c5f1d3ad1448a6137f6e"
@@ -327,6 +373,19 @@
     "@babel/helper-replace-supers" "^7.14.5"
     "@babel/helper-split-export-declaration" "^7.14.5"
 
+"@babel/helper-create-class-features-plugin@^7.16.10", "@babel/helper-create-class-features-plugin@^7.16.7", "@babel/helper-create-class-features-plugin@^7.17.6":
+  version "7.17.9"
+  resolved "https://registry.yarnpkg.com/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.17.9.tgz#71835d7fb9f38bd9f1378e40a4c0902fdc2ea49d"
+  integrity sha512-kUjip3gruz6AJKOq5i3nC6CoCEEF/oHH3cp6tOZhB+IyyyPyW0g1Gfsxn3mkk6S08pIA2y8GQh609v9G/5sHVQ==
+  dependencies:
+    "@babel/helper-annotate-as-pure" "^7.16.7"
+    "@babel/helper-environment-visitor" "^7.16.7"
+    "@babel/helper-function-name" "^7.17.9"
+    "@babel/helper-member-expression-to-functions" "^7.17.7"
+    "@babel/helper-optimise-call-expression" "^7.16.7"
+    "@babel/helper-replace-supers" "^7.16.7"
+    "@babel/helper-split-export-declaration" "^7.16.7"
+
 "@babel/helper-create-regexp-features-plugin@^7.10.4", "@babel/helper-create-regexp-features-plugin@^7.12.1":
   version "7.12.1"
   resolved "https://registry.yarnpkg.com/@babel/helper-create-regexp-features-plugin/-/helper-create-regexp-features-plugin-7.12.1.tgz#18b1302d4677f9dc4740fe8c9ed96680e29d37e8"
@@ -351,6 +410,14 @@
   dependencies:
     "@babel/helper-annotate-as-pure" "^7.14.5"
     regexpu-core "^4.7.1"
+
+"@babel/helper-create-regexp-features-plugin@^7.16.7":
+  version "7.17.0"
+  resolved "https://registry.yarnpkg.com/@babel/helper-create-regexp-features-plugin/-/helper-create-regexp-features-plugin-7.17.0.tgz#1dcc7d40ba0c6b6b25618997c5dbfd310f186fe1"
+  integrity sha512-awO2So99wG6KnlE+TPs6rn83gCz5WlEePJDTnLEqbchMVrBeAujURVphRdigsk094VhvZehFoNOihSlcBjwsXA==
+  dependencies:
+    "@babel/helper-annotate-as-pure" "^7.16.7"
+    regexpu-core "^5.0.1"
 
 "@babel/helper-define-map@^7.10.4":
   version "7.10.5"
@@ -389,6 +456,27 @@
     resolve "^1.14.2"
     semver "^6.1.2"
 
+"@babel/helper-define-polyfill-provider@^0.3.1":
+  version "0.3.1"
+  resolved "https://registry.yarnpkg.com/@babel/helper-define-polyfill-provider/-/helper-define-polyfill-provider-0.3.1.tgz#52411b445bdb2e676869e5a74960d2d3826d2665"
+  integrity sha512-J9hGMpJQmtWmj46B3kBHmL38UhJGhYX7eqkcq+2gsstyYt341HmPeWspihX43yVRA0mS+8GGk2Gckc7bY/HCmA==
+  dependencies:
+    "@babel/helper-compilation-targets" "^7.13.0"
+    "@babel/helper-module-imports" "^7.12.13"
+    "@babel/helper-plugin-utils" "^7.13.0"
+    "@babel/traverse" "^7.13.0"
+    debug "^4.1.1"
+    lodash.debounce "^4.0.8"
+    resolve "^1.14.2"
+    semver "^6.1.2"
+
+"@babel/helper-environment-visitor@^7.16.7":
+  version "7.16.7"
+  resolved "https://registry.yarnpkg.com/@babel/helper-environment-visitor/-/helper-environment-visitor-7.16.7.tgz#ff484094a839bde9d89cd63cba017d7aae80ecd7"
+  integrity sha512-SLLb0AAn6PkUeAfKJCCOl9e1R53pQlGAfc4y4XuMRZfqeMYLE0dM1LMhqbGAlGQY0lfw5/ohoYWAe9V1yibRag==
+  dependencies:
+    "@babel/types" "^7.16.7"
+
 "@babel/helper-explode-assignable-expression@^7.10.4":
   version "7.12.1"
   resolved "https://registry.yarnpkg.com/@babel/helper-explode-assignable-expression/-/helper-explode-assignable-expression-7.12.1.tgz#8006a466695c4ad86a2a5f2fb15b5f2c31ad5633"
@@ -410,6 +498,13 @@
   dependencies:
     "@babel/types" "^7.14.5"
 
+"@babel/helper-explode-assignable-expression@^7.16.7":
+  version "7.16.7"
+  resolved "https://registry.yarnpkg.com/@babel/helper-explode-assignable-expression/-/helper-explode-assignable-expression-7.16.7.tgz#12a6d8522fdd834f194e868af6354e8650242b7a"
+  integrity sha512-KyUenhWMC8VrxzkGP0Jizjo4/Zx+1nNZhgocs+gLzyZyB8SHidhoq9KK/8Ato4anhwsivfkBLftky7gvzbZMtQ==
+  dependencies:
+    "@babel/types" "^7.16.7"
+
 "@babel/helper-function-name@^7.10.4", "@babel/helper-function-name@^7.14.5":
   version "7.14.5"
   resolved "https://registry.yarnpkg.com/@babel/helper-function-name/-/helper-function-name-7.14.5.tgz#89e2c474972f15d8e233b52ee8c480e2cfcd50c4"
@@ -427,6 +522,14 @@
     "@babel/helper-get-function-arity" "^7.12.13"
     "@babel/template" "^7.12.13"
     "@babel/types" "^7.12.13"
+
+"@babel/helper-function-name@^7.16.7", "@babel/helper-function-name@^7.17.9":
+  version "7.17.9"
+  resolved "https://registry.yarnpkg.com/@babel/helper-function-name/-/helper-function-name-7.17.9.tgz#136fcd54bc1da82fcb47565cf16fd8e444b1ff12"
+  integrity sha512-7cRisGlVtiVqZ0MW0/yFB4atgpGLWEHUVYnb448hZK4x+vih0YO5UoS11XIYtZYqHd0dIPMdUSv8q5K4LdMnIg==
+  dependencies:
+    "@babel/template" "^7.16.7"
+    "@babel/types" "^7.17.0"
 
 "@babel/helper-get-function-arity@^7.10.4", "@babel/helper-get-function-arity@^7.14.5":
   version "7.14.5"
@@ -464,6 +567,13 @@
   dependencies:
     "@babel/types" "^7.14.5"
 
+"@babel/helper-hoist-variables@^7.16.7":
+  version "7.16.7"
+  resolved "https://registry.yarnpkg.com/@babel/helper-hoist-variables/-/helper-hoist-variables-7.16.7.tgz#86bcb19a77a509c7b77d0e22323ef588fa58c246"
+  integrity sha512-m04d/0Op34H5v7pbZw6pSKP7weA6lsMvfiIAMeIvkY/R4xQtBSMFEigu9QTZ2qB/9l22vsxtM8a+Q8CzD255fg==
+  dependencies:
+    "@babel/types" "^7.16.7"
+
 "@babel/helper-member-expression-to-functions@^7.12.1", "@babel/helper-member-expression-to-functions@^7.14.5":
   version "7.14.7"
   resolved "https://registry.yarnpkg.com/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.14.7.tgz#97e56244beb94211fe277bd818e3a329c66f7970"
@@ -477,6 +587,13 @@
   integrity sha512-yvRf8Ivk62JwisqV1rFRMxiSMDGnN6KH1/mDMmIrij4jztpQNRoHqqMG3U6apYbGRPJpgPalhva9Yd06HlUxJQ==
   dependencies:
     "@babel/types" "^7.13.0"
+
+"@babel/helper-member-expression-to-functions@^7.16.7", "@babel/helper-member-expression-to-functions@^7.17.7":
+  version "7.17.7"
+  resolved "https://registry.yarnpkg.com/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.17.7.tgz#a34013b57d8542a8c4ff8ba3f747c02452a4d8c4"
+  integrity sha512-thxXgnQ8qQ11W2wVUObIqDL4p148VMxkt5T/qpN5k2fboRyzFGFmKsTGViquyM5QHKUy48OZoca8kw4ajaDPyw==
+  dependencies:
+    "@babel/types" "^7.17.0"
 
 "@babel/helper-module-imports@^7.0.0":
   version "7.10.4"
@@ -505,6 +622,13 @@
   integrity sha512-NGmfvRp9Rqxy0uHSSVP+SRIW1q31a7Ji10cLBcqSDUngGentY4FRiHOFZFE1CLU5eiL0oE8reH7Tg1y99TDM/g==
   dependencies:
     "@babel/types" "^7.12.13"
+
+"@babel/helper-module-imports@^7.16.7":
+  version "7.16.7"
+  resolved "https://registry.yarnpkg.com/@babel/helper-module-imports/-/helper-module-imports-7.16.7.tgz#25612a8091a999704461c8a222d0efec5d091437"
+  integrity sha512-LVtS6TqjJHFc+nYeITRo6VLXve70xmq7wPhWTqDJusJEgGmkAACWwMiTNrvfoQo6hEhFwAIixNkvB0jPXDL8Wg==
+  dependencies:
+    "@babel/types" "^7.16.7"
 
 "@babel/helper-module-transforms@^7.10.4", "@babel/helper-module-transforms@^7.12.1", "@babel/helper-module-transforms@^7.9.0":
   version "7.12.1"
@@ -564,6 +688,20 @@
     "@babel/traverse" "^7.14.8"
     "@babel/types" "^7.14.8"
 
+"@babel/helper-module-transforms@^7.16.7", "@babel/helper-module-transforms@^7.17.7":
+  version "7.17.7"
+  resolved "https://registry.yarnpkg.com/@babel/helper-module-transforms/-/helper-module-transforms-7.17.7.tgz#3943c7f777139e7954a5355c815263741a9c1cbd"
+  integrity sha512-VmZD99F3gNTYB7fJRDTi+u6l/zxY0BE6OIxPSU7a50s6ZUQkHwSDmV92FfM+oCG0pZRVojGYhkR8I0OGeCVREw==
+  dependencies:
+    "@babel/helper-environment-visitor" "^7.16.7"
+    "@babel/helper-module-imports" "^7.16.7"
+    "@babel/helper-simple-access" "^7.17.7"
+    "@babel/helper-split-export-declaration" "^7.16.7"
+    "@babel/helper-validator-identifier" "^7.16.7"
+    "@babel/template" "^7.16.7"
+    "@babel/traverse" "^7.17.3"
+    "@babel/types" "^7.17.0"
+
 "@babel/helper-optimise-call-expression@^7.10.4", "@babel/helper-optimise-call-expression@^7.14.5":
   version "7.14.5"
   resolved "https://registry.yarnpkg.com/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.14.5.tgz#f27395a8619e0665b3f0364cddb41c25d71b499c"
@@ -577,6 +715,13 @@
   integrity sha512-BdWQhoVJkp6nVjB7nkFWcn43dkprYauqtk++Py2eaf/GRDFm5BxRqEIZCiHlZUGAVmtwKcsVL1dC68WmzeFmiA==
   dependencies:
     "@babel/types" "^7.12.13"
+
+"@babel/helper-optimise-call-expression@^7.16.7":
+  version "7.16.7"
+  resolved "https://registry.yarnpkg.com/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.16.7.tgz#a34e3560605abbd31a18546bd2aad3e6d9a174f2"
+  integrity sha512-EtgBhg7rd/JcnpZFXpBy0ze1YRfdm7BnBX4uKMBd3ixa3RGAE002JZB66FJyNH7g0F38U05pXmA5P8cBh7z+1w==
+  dependencies:
+    "@babel/types" "^7.16.7"
 
 "@babel/helper-plugin-utils@7.10.4", "@babel/helper-plugin-utils@^7.8.3":
   version "7.10.4"
@@ -592,6 +737,11 @@
   version "7.13.0"
   resolved "https://registry.yarnpkg.com/@babel/helper-plugin-utils/-/helper-plugin-utils-7.13.0.tgz#806526ce125aed03373bc416a828321e3a6a33af"
   integrity sha512-ZPafIPSwzUlAoWT8DKs1W2VyF2gOWthGd5NGFMsBcMMol+ZhK+EQY/e6V96poa6PA/Bh+C9plWN0hXO1uB8AfQ==
+
+"@babel/helper-plugin-utils@^7.16.7":
+  version "7.16.7"
+  resolved "https://registry.yarnpkg.com/@babel/helper-plugin-utils/-/helper-plugin-utils-7.16.7.tgz#aa3a8ab4c3cceff8e65eb9e73d87dc4ff320b2f5"
+  integrity sha512-Qg3Nk7ZxpgMrsox6HreY1ZNKdBq7K72tDSliA6dCl5f007jR4ne8iD5UzuNnCJH2xBf2BEEVGr+/OL6Gdp7RxA==
 
 "@babel/helper-regex@^7.10.4":
   version "7.10.5"
@@ -627,6 +777,15 @@
     "@babel/helper-wrap-function" "^7.14.5"
     "@babel/types" "^7.14.5"
 
+"@babel/helper-remap-async-to-generator@^7.16.8":
+  version "7.16.8"
+  resolved "https://registry.yarnpkg.com/@babel/helper-remap-async-to-generator/-/helper-remap-async-to-generator-7.16.8.tgz#29ffaade68a367e2ed09c90901986918d25e57e3"
+  integrity sha512-fm0gH7Flb8H51LqJHy3HJ3wnE1+qtYR2A99K06ahwrawLdOFsCEWjZOrYricXJHoPSudNKxrMBUPEIPxiIIvBw==
+  dependencies:
+    "@babel/helper-annotate-as-pure" "^7.16.7"
+    "@babel/helper-wrap-function" "^7.16.8"
+    "@babel/types" "^7.16.8"
+
 "@babel/helper-replace-supers@^7.10.4":
   version "7.12.5"
   resolved "https://registry.yarnpkg.com/@babel/helper-replace-supers/-/helper-replace-supers-7.12.5.tgz#f009a17543bbbbce16b06206ae73b63d3fca68d9"
@@ -657,6 +816,17 @@
     "@babel/traverse" "^7.13.0"
     "@babel/types" "^7.13.0"
 
+"@babel/helper-replace-supers@^7.16.7":
+  version "7.16.7"
+  resolved "https://registry.yarnpkg.com/@babel/helper-replace-supers/-/helper-replace-supers-7.16.7.tgz#e9f5f5f32ac90429c1a4bdec0f231ef0c2838ab1"
+  integrity sha512-y9vsWilTNaVnVh6xiJfABzsNpgDPKev9HnAgz6Gb1p6UUwf9NepdlsV7VXGCftJM+jqD5f7JIEubcpLjZj5dBw==
+  dependencies:
+    "@babel/helper-environment-visitor" "^7.16.7"
+    "@babel/helper-member-expression-to-functions" "^7.16.7"
+    "@babel/helper-optimise-call-expression" "^7.16.7"
+    "@babel/traverse" "^7.16.7"
+    "@babel/types" "^7.16.7"
+
 "@babel/helper-simple-access@^7.10.4":
   version "7.12.1"
   resolved "https://registry.yarnpkg.com/@babel/helper-simple-access/-/helper-simple-access-7.12.1.tgz#32427e5aa61547d38eb1e6eaf5fd1426fdad9136"
@@ -685,6 +855,13 @@
   dependencies:
     "@babel/types" "^7.14.8"
 
+"@babel/helper-simple-access@^7.17.7":
+  version "7.17.7"
+  resolved "https://registry.yarnpkg.com/@babel/helper-simple-access/-/helper-simple-access-7.17.7.tgz#aaa473de92b7987c6dfa7ce9a7d9674724823367"
+  integrity sha512-txyMCGroZ96i+Pxr3Je3lzEJjqwaRC9buMUgtomcrLe5Nd0+fk1h0LLA+ixUF5OW7AhHuQ7Es1WcQJZmZsz2XA==
+  dependencies:
+    "@babel/types" "^7.17.0"
+
 "@babel/helper-skip-transparent-expression-wrappers@^7.11.0", "@babel/helper-skip-transparent-expression-wrappers@^7.12.1":
   version "7.12.1"
   resolved "https://registry.yarnpkg.com/@babel/helper-skip-transparent-expression-wrappers/-/helper-skip-transparent-expression-wrappers-7.12.1.tgz#462dc63a7e435ade8468385c63d2b84cce4b3cbf"
@@ -698,6 +875,13 @@
   integrity sha512-dmqZB7mrb94PZSAOYtr+ZN5qt5owZIAgqtoTuqiFbHFtxgEcmQlRJVI+bO++fciBunXtB6MK7HrzrfcAzIz2NQ==
   dependencies:
     "@babel/types" "^7.14.5"
+
+"@babel/helper-skip-transparent-expression-wrappers@^7.16.0":
+  version "7.16.0"
+  resolved "https://registry.yarnpkg.com/@babel/helper-skip-transparent-expression-wrappers/-/helper-skip-transparent-expression-wrappers-7.16.0.tgz#0ee3388070147c3ae051e487eca3ebb0e2e8bb09"
+  integrity sha512-+il1gTy0oHwUsBQZyJvukbB4vPMdcYBrFHa0Uc4AizLxbq6BOYC51Rv4tWocX9BLBDLZ4kc6qUFpQ6HRgL+3zw==
+  dependencies:
+    "@babel/types" "^7.16.0"
 
 "@babel/helper-split-export-declaration@^7.10.4":
   version "7.11.0"
@@ -720,6 +904,13 @@
   dependencies:
     "@babel/types" "^7.12.13"
 
+"@babel/helper-split-export-declaration@^7.16.7":
+  version "7.16.7"
+  resolved "https://registry.yarnpkg.com/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.16.7.tgz#0b648c0c42da9d3920d85ad585f2778620b8726b"
+  integrity sha512-xbWoy/PFoxSWazIToT9Sif+jJTlrMcndIsaOKvTA6u7QEo7ilkRZpjew18/W3c7nm8fXdUDXh02VXTbZ0pGDNw==
+  dependencies:
+    "@babel/types" "^7.16.7"
+
 "@babel/helper-validator-identifier@^7.10.4", "@babel/helper-validator-identifier@^7.14.5":
   version "7.14.5"
   resolved "https://registry.yarnpkg.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.14.5.tgz#d0f0e277c512e0c938277faa85a3968c9a44c0e8"
@@ -735,6 +926,11 @@
   resolved "https://registry.yarnpkg.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.14.8.tgz#32be33a756f29e278a0d644fa08a2c9e0f88a34c"
   integrity sha512-ZGy6/XQjllhYQrNw/3zfWRwZCTVSiBLZ9DHVZxn9n2gip/7ab8mv2TWlKPIBk26RwedCBoWdjLmn+t9na2Gcow==
 
+"@babel/helper-validator-identifier@^7.16.7":
+  version "7.16.7"
+  resolved "https://registry.yarnpkg.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.16.7.tgz#e8c602438c4a8195751243da9031d1607d247cad"
+  integrity sha512-hsEnFemeiW4D08A5gUAZxLBTXpZ39P+a+DGDsHw1yxqyQ/jzFEnxf5uTEGp+3bzAbNOxU1paTgYS4ECU/IgfDw==
+
 "@babel/helper-validator-option@^7.12.1":
   version "7.12.1"
   resolved "https://registry.yarnpkg.com/@babel/helper-validator-option/-/helper-validator-option-7.12.1.tgz#175567380c3e77d60ff98a54bb015fe78f2178d9"
@@ -749,6 +945,11 @@
   version "7.14.5"
   resolved "https://registry.yarnpkg.com/@babel/helper-validator-option/-/helper-validator-option-7.14.5.tgz#6e72a1fff18d5dfcb878e1e62f1a021c4b72d5a3"
   integrity sha512-OX8D5eeX4XwcroVW45NMvoYaIuFI+GQpA2a8Gi+X/U/cDUIRsV37qQfF905F0htTRCREQIB4KqPeaveRJUl3Ow==
+
+"@babel/helper-validator-option@^7.16.7":
+  version "7.16.7"
+  resolved "https://registry.yarnpkg.com/@babel/helper-validator-option/-/helper-validator-option-7.16.7.tgz#b203ce62ce5fe153899b617c08957de860de4d23"
+  integrity sha512-TRtenOuRUVo9oIQGPC5G9DgK4743cdxvtOw0weQNpZXaS16SCBi5MNjZF8vba3ETURjZpTbVn7Vvcf2eAwFozQ==
 
 "@babel/helper-wrap-function@^7.10.4":
   version "7.12.3"
@@ -779,6 +980,16 @@
     "@babel/template" "^7.14.5"
     "@babel/traverse" "^7.14.5"
     "@babel/types" "^7.14.5"
+
+"@babel/helper-wrap-function@^7.16.8":
+  version "7.16.8"
+  resolved "https://registry.yarnpkg.com/@babel/helper-wrap-function/-/helper-wrap-function-7.16.8.tgz#58afda087c4cd235de92f7ceedebca2c41274200"
+  integrity sha512-8RpyRVIAW1RcDDGTA+GpPAwV22wXCfKOoM9bet6TLkGIFTkRQSkH1nMQ5Yet4MpoXe1ZwHPVtNasc2w0uZMqnw==
+  dependencies:
+    "@babel/helper-function-name" "^7.16.7"
+    "@babel/template" "^7.16.7"
+    "@babel/traverse" "^7.16.8"
+    "@babel/types" "^7.16.8"
 
 "@babel/helpers@^7.10.4", "@babel/helpers@^7.14.6":
   version "7.14.6"
@@ -825,6 +1036,15 @@
     chalk "^2.0.0"
     js-tokens "^4.0.0"
 
+"@babel/highlight@^7.16.7":
+  version "7.17.9"
+  resolved "https://registry.yarnpkg.com/@babel/highlight/-/highlight-7.17.9.tgz#61b2ee7f32ea0454612def4fccdae0de232b73e3"
+  integrity sha512-J9PfEKCbFIv2X5bjTMiZu6Vf341N05QIY+d6FvVKynkG1S7G0j3I0QoRtWIrXhZ+/Nlb5Q0MzqL7TokEJ5BNHg==
+  dependencies:
+    "@babel/helper-validator-identifier" "^7.16.7"
+    chalk "^2.0.0"
+    js-tokens "^4.0.0"
+
 "@babel/parser@^7.0.0":
   version "7.11.5"
   resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.11.5.tgz#c7ff6303df71080ec7a4f5b8c003c58f1cf51037"
@@ -850,10 +1070,22 @@
   resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.12.7.tgz#fee7b39fe809d0e73e5b25eecaf5780ef3d73056"
   integrity sha512-oWR02Ubp4xTLCAqPRiNIuMVgNO5Aif/xpXtabhzW2HWUD47XJsAB4Zd/Rg30+XeQA3juXigV7hlquOTmwqLiwg==
 
+"@babel/parser@^7.16.7", "@babel/parser@^7.17.9":
+  version "7.17.9"
+  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.17.9.tgz#9c94189a6062f0291418ca021077983058e171ef"
+  integrity sha512-vqUSBLP8dQHFPdPi9bc5GK9vRkYHJ49fsZdtoJ8EQ8ibpwk5rPKfvNIwChB0KVXcIjcepEBBd2VHC5r9Gy8ueg==
+
 "@babel/parser@^7.9.0":
   version "7.12.5"
   resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.12.5.tgz#b4af32ddd473c0bfa643bd7ff0728b8e71b81ea0"
   integrity sha512-FVM6RZQ0mn2KCf1VUED7KepYeUWoVShczewOCfm3nzoBybaih51h+sYVVGthW9M6lPByEPTQf+xm27PBdlpwmQ==
+
+"@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression@^7.16.7":
+  version "7.16.7"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression/-/plugin-bugfix-safari-id-destructuring-collision-in-function-expression-7.16.7.tgz#4eda6d6c2a0aa79c70fa7b6da67763dfe2141050"
+  integrity sha512-anv/DObl7waiGEnC24O9zqL0pSuI9hljihqiDuFHC8d7/bjr/4RLGPWuc8rYOff/QPzbEPSkzG8wGG9aDuhHRg==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.16.7"
 
 "@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining@^7.14.5":
   version "7.14.5"
@@ -863,6 +1095,15 @@
     "@babel/helper-plugin-utils" "^7.14.5"
     "@babel/helper-skip-transparent-expression-wrappers" "^7.14.5"
     "@babel/plugin-proposal-optional-chaining" "^7.14.5"
+
+"@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining@^7.16.7":
+  version "7.16.7"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining/-/plugin-bugfix-v8-spread-parameters-in-optional-chaining-7.16.7.tgz#cc001234dfc139ac45f6bcf801866198c8c72ff9"
+  integrity sha512-di8vUHRdf+4aJ7ltXhaDbPoszdkh59AQtJM5soLsuHpQJdFQZOA4uGj0V2u/CZ8bJ/u8ULDL5yq6FO/bCXnKHw==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.16.7"
+    "@babel/helper-skip-transparent-expression-wrappers" "^7.16.0"
+    "@babel/plugin-proposal-optional-chaining" "^7.16.7"
 
 "@babel/plugin-external-helpers@^7.0.0":
   version "7.10.4"
@@ -898,6 +1139,15 @@
     "@babel/helper-remap-async-to-generator" "^7.14.5"
     "@babel/plugin-syntax-async-generators" "^7.8.4"
 
+"@babel/plugin-proposal-async-generator-functions@^7.16.8":
+  version "7.16.8"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-async-generator-functions/-/plugin-proposal-async-generator-functions-7.16.8.tgz#3bdd1ebbe620804ea9416706cd67d60787504bc8"
+  integrity sha512-71YHIvMuiuqWJQkebWJtdhQTfd4Q4mF76q2IX37uZPkG9+olBxsX+rH1vkhFto4UeJZ9dPY2s+mDvhDm1u2BGQ==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.16.7"
+    "@babel/helper-remap-async-to-generator" "^7.16.8"
+    "@babel/plugin-syntax-async-generators" "^7.8.4"
+
 "@babel/plugin-proposal-class-properties@^7.0.0":
   version "7.10.4"
   resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-class-properties/-/plugin-proposal-class-properties-7.10.4.tgz#a33bf632da390a59c7a8c570045d1115cd778807"
@@ -930,6 +1180,14 @@
     "@babel/helper-create-class-features-plugin" "^7.14.5"
     "@babel/helper-plugin-utils" "^7.14.5"
 
+"@babel/plugin-proposal-class-properties@^7.16.7":
+  version "7.16.7"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-class-properties/-/plugin-proposal-class-properties-7.16.7.tgz#925cad7b3b1a2fcea7e59ecc8eb5954f961f91b0"
+  integrity sha512-IobU0Xme31ewjYOShSIqd/ZGM/r/cuOz2z0MDbNrhF5FW+ZVgi0f2lyeoj9KFPDOAqsYxmLWZte1WOwlvY9aww==
+  dependencies:
+    "@babel/helper-create-class-features-plugin" "^7.16.7"
+    "@babel/helper-plugin-utils" "^7.16.7"
+
 "@babel/plugin-proposal-class-properties@~7.12.13":
   version "7.12.13"
   resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-class-properties/-/plugin-proposal-class-properties-7.12.13.tgz#3d2ce350367058033c93c098e348161d6dc0d8c8"
@@ -945,6 +1203,15 @@
   dependencies:
     "@babel/helper-create-class-features-plugin" "^7.14.5"
     "@babel/helper-plugin-utils" "^7.14.5"
+    "@babel/plugin-syntax-class-static-block" "^7.14.5"
+
+"@babel/plugin-proposal-class-static-block@^7.16.7":
+  version "7.17.6"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-class-static-block/-/plugin-proposal-class-static-block-7.17.6.tgz#164e8fd25f0d80fa48c5a4d1438a6629325ad83c"
+  integrity sha512-X/tididvL2zbs7jZCeeRJ8167U/+Ac135AM6jCAx6gYXDUviZV5Ku9UDvWS2NCuWlFjIRXklYhwo6HhAC7ETnA==
+  dependencies:
+    "@babel/helper-create-class-features-plugin" "^7.17.6"
+    "@babel/helper-plugin-utils" "^7.16.7"
     "@babel/plugin-syntax-class-static-block" "^7.14.5"
 
 "@babel/plugin-proposal-decorators@^7.12.12":
@@ -989,6 +1256,14 @@
     "@babel/helper-plugin-utils" "^7.14.5"
     "@babel/plugin-syntax-dynamic-import" "^7.8.3"
 
+"@babel/plugin-proposal-dynamic-import@^7.16.7":
+  version "7.16.7"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-dynamic-import/-/plugin-proposal-dynamic-import-7.16.7.tgz#c19c897eaa46b27634a00fee9fb7d829158704b2"
+  integrity sha512-I8SW9Ho3/8DRSdmDdH3gORdyUuYnk1m4cMxUAdu5oy4n3OfN8flDEH+d60iG7dUfi0KkYwSvoalHzzdRzpWHTg==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.16.7"
+    "@babel/plugin-syntax-dynamic-import" "^7.8.3"
+
 "@babel/plugin-proposal-export-default-from@^7.0.0":
   version "7.10.4"
   resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-export-default-from/-/plugin-proposal-export-default-from-7.10.4.tgz#08f66eef0067cbf6a7bc036977dcdccecaf0c6c5"
@@ -1029,6 +1304,14 @@
     "@babel/helper-plugin-utils" "^7.14.5"
     "@babel/plugin-syntax-export-namespace-from" "^7.8.3"
 
+"@babel/plugin-proposal-export-namespace-from@^7.16.7":
+  version "7.16.7"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-export-namespace-from/-/plugin-proposal-export-namespace-from-7.16.7.tgz#09de09df18445a5786a305681423ae63507a6163"
+  integrity sha512-ZxdtqDXLRGBL64ocZcs7ovt71L3jhC1RGSyR996svrCi3PYqHNkb3SwPJCs8RIzD86s+WPpt2S73+EHCGO+NUA==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.16.7"
+    "@babel/plugin-syntax-export-namespace-from" "^7.8.3"
+
 "@babel/plugin-proposal-json-strings@^7.10.4":
   version "7.12.1"
   resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-json-strings/-/plugin-proposal-json-strings-7.12.1.tgz#d45423b517714eedd5621a9dfdc03fa9f4eb241c"
@@ -1053,6 +1336,14 @@
     "@babel/helper-plugin-utils" "^7.14.5"
     "@babel/plugin-syntax-json-strings" "^7.8.3"
 
+"@babel/plugin-proposal-json-strings@^7.16.7":
+  version "7.16.7"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-json-strings/-/plugin-proposal-json-strings-7.16.7.tgz#9732cb1d17d9a2626a08c5be25186c195b6fa6e8"
+  integrity sha512-lNZ3EEggsGY78JavgbHsK9u5P3pQaW7k4axlgFLYkMd7UBsiNahCITShLjNQschPyjtO6dADrL24757IdhBrsQ==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.16.7"
+    "@babel/plugin-syntax-json-strings" "^7.8.3"
+
 "@babel/plugin-proposal-logical-assignment-operators@^7.11.0":
   version "7.12.1"
   resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-logical-assignment-operators/-/plugin-proposal-logical-assignment-operators-7.12.1.tgz#f2c490d36e1b3c9659241034a5d2cd50263a2751"
@@ -1075,6 +1366,14 @@
   integrity sha512-YGn2AvZAo9TwyhlLvCCWxD90Xq8xJ4aSgaX3G5D/8DW94L8aaT+dS5cSP+Z06+rCJERGSr9GxMBZ601xoc2taw==
   dependencies:
     "@babel/helper-plugin-utils" "^7.14.5"
+    "@babel/plugin-syntax-logical-assignment-operators" "^7.10.4"
+
+"@babel/plugin-proposal-logical-assignment-operators@^7.16.7":
+  version "7.16.7"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-logical-assignment-operators/-/plugin-proposal-logical-assignment-operators-7.16.7.tgz#be23c0ba74deec1922e639832904be0bea73cdea"
+  integrity sha512-K3XzyZJGQCr00+EtYtrDjmwX7o7PLK6U9bi1nCwkQioRFVUv6dJoxbQjtWVtP+bCPy82bONBKG8NPyQ4+i6yjg==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.16.7"
     "@babel/plugin-syntax-logical-assignment-operators" "^7.10.4"
 
 "@babel/plugin-proposal-nullish-coalescing-operator@^7.0.0":
@@ -1109,6 +1408,14 @@
     "@babel/helper-plugin-utils" "^7.14.5"
     "@babel/plugin-syntax-nullish-coalescing-operator" "^7.8.3"
 
+"@babel/plugin-proposal-nullish-coalescing-operator@^7.16.7":
+  version "7.16.7"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-nullish-coalescing-operator/-/plugin-proposal-nullish-coalescing-operator-7.16.7.tgz#141fc20b6857e59459d430c850a0011e36561d99"
+  integrity sha512-aUOrYU3EVtjf62jQrCj63pYZ7k6vns2h/DQvHPWGmsJRYzWXZ6/AsfgpiRy6XiuIDADhJzP2Q9MwSMKauBQ+UQ==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.16.7"
+    "@babel/plugin-syntax-nullish-coalescing-operator" "^7.8.3"
+
 "@babel/plugin-proposal-numeric-separator@^7.10.4":
   version "7.12.5"
   resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-numeric-separator/-/plugin-proposal-numeric-separator-7.12.5.tgz#b1ce757156d40ed79d59d467cb2b154a5c4149ba"
@@ -1131,6 +1438,14 @@
   integrity sha512-yiclALKe0vyZRZE0pS6RXgjUOt87GWv6FYa5zqj15PvhOGFO69R5DusPlgK/1K5dVnCtegTiWu9UaBSrLLJJBg==
   dependencies:
     "@babel/helper-plugin-utils" "^7.14.5"
+    "@babel/plugin-syntax-numeric-separator" "^7.10.4"
+
+"@babel/plugin-proposal-numeric-separator@^7.16.7":
+  version "7.16.7"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-numeric-separator/-/plugin-proposal-numeric-separator-7.16.7.tgz#d6b69f4af63fb38b6ca2558442a7fb191236eba9"
+  integrity sha512-vQgPMknOIgiuVqbokToyXbkY/OmmjAzr/0lhSIbG/KmnzXPGwW/AdhdKpi+O4X/VkWiWjnkKOBiqJrTaC98VKw==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.16.7"
     "@babel/plugin-syntax-numeric-separator" "^7.10.4"
 
 "@babel/plugin-proposal-object-rest-spread@7.12.1", "@babel/plugin-proposal-object-rest-spread@^7.11.0", "@babel/plugin-proposal-object-rest-spread@^7.12.1":
@@ -1173,6 +1488,17 @@
     "@babel/plugin-syntax-object-rest-spread" "^7.8.3"
     "@babel/plugin-transform-parameters" "^7.14.5"
 
+"@babel/plugin-proposal-object-rest-spread@^7.16.7":
+  version "7.17.3"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.17.3.tgz#d9eb649a54628a51701aef7e0ea3d17e2b9dd390"
+  integrity sha512-yuL5iQA/TbZn+RGAfxQXfi7CNLmKi1f8zInn4IgobuCWcAb7i+zj4TYzQ9l8cEzVyJ89PDGuqxK1xZpUDISesw==
+  dependencies:
+    "@babel/compat-data" "^7.17.0"
+    "@babel/helper-compilation-targets" "^7.16.7"
+    "@babel/helper-plugin-utils" "^7.16.7"
+    "@babel/plugin-syntax-object-rest-spread" "^7.8.3"
+    "@babel/plugin-transform-parameters" "^7.16.7"
+
 "@babel/plugin-proposal-optional-catch-binding@^7.0.0":
   version "7.10.4"
   resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-optional-catch-binding/-/plugin-proposal-optional-catch-binding-7.10.4.tgz#31c938309d24a78a49d68fdabffaa863758554dd"
@@ -1203,6 +1529,14 @@
   integrity sha512-3Oyiixm0ur7bzO5ybNcZFlmVsygSIQgdOa7cTfOYCMY+wEPAYhZAJxi3mixKFCTCKUhQXuCTtQ1MzrpL3WT8ZQ==
   dependencies:
     "@babel/helper-plugin-utils" "^7.14.5"
+    "@babel/plugin-syntax-optional-catch-binding" "^7.8.3"
+
+"@babel/plugin-proposal-optional-catch-binding@^7.16.7":
+  version "7.16.7"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-optional-catch-binding/-/plugin-proposal-optional-catch-binding-7.16.7.tgz#c623a430674ffc4ab732fd0a0ae7722b67cb74cf"
+  integrity sha512-eMOH/L4OvWSZAE1VkHbr1vckLG1WUcHGJSLqqQwl2GaUqG6QjddvrOaTUMNYiv77H5IKPMZ9U9P7EaHwvAShfA==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.16.7"
     "@babel/plugin-syntax-optional-catch-binding" "^7.8.3"
 
 "@babel/plugin-proposal-optional-chaining@^7.0.0":
@@ -1241,6 +1575,15 @@
     "@babel/helper-skip-transparent-expression-wrappers" "^7.14.5"
     "@babel/plugin-syntax-optional-chaining" "^7.8.3"
 
+"@babel/plugin-proposal-optional-chaining@^7.16.7":
+  version "7.16.7"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-optional-chaining/-/plugin-proposal-optional-chaining-7.16.7.tgz#7cd629564724816c0e8a969535551f943c64c39a"
+  integrity sha512-eC3xy+ZrUcBtP7x+sq62Q/HYd674pPTb/77XZMb5wbDPGWIdUbSr4Agr052+zaUPSb+gGRnjxXfKFvx5iMJ+DA==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.16.7"
+    "@babel/helper-skip-transparent-expression-wrappers" "^7.16.0"
+    "@babel/plugin-syntax-optional-chaining" "^7.8.3"
+
 "@babel/plugin-proposal-private-methods@^7.10.4", "@babel/plugin-proposal-private-methods@^7.12.1":
   version "7.12.1"
   resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-private-methods/-/plugin-proposal-private-methods-7.12.1.tgz#86814f6e7a21374c980c10d38b4493e703f4a389"
@@ -1265,6 +1608,14 @@
     "@babel/helper-create-class-features-plugin" "^7.14.5"
     "@babel/helper-plugin-utils" "^7.14.5"
 
+"@babel/plugin-proposal-private-methods@^7.16.11":
+  version "7.16.11"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-private-methods/-/plugin-proposal-private-methods-7.16.11.tgz#e8df108288555ff259f4527dbe84813aac3a1c50"
+  integrity sha512-F/2uAkPlXDr8+BHpZvo19w3hLFKge+k75XUprE6jaqKxjGkSYcK+4c+bup5PdW/7W/Rpjwql7FTVEDW+fRAQsw==
+  dependencies:
+    "@babel/helper-create-class-features-plugin" "^7.16.10"
+    "@babel/helper-plugin-utils" "^7.16.7"
+
 "@babel/plugin-proposal-private-property-in-object@^7.14.5":
   version "7.14.5"
   resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-private-property-in-object/-/plugin-proposal-private-property-in-object-7.14.5.tgz#9f65a4d0493a940b4c01f8aa9d3f1894a587f636"
@@ -1273,6 +1624,16 @@
     "@babel/helper-annotate-as-pure" "^7.14.5"
     "@babel/helper-create-class-features-plugin" "^7.14.5"
     "@babel/helper-plugin-utils" "^7.14.5"
+    "@babel/plugin-syntax-private-property-in-object" "^7.14.5"
+
+"@babel/plugin-proposal-private-property-in-object@^7.16.7":
+  version "7.16.7"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-private-property-in-object/-/plugin-proposal-private-property-in-object-7.16.7.tgz#b0b8cef543c2c3d57e59e2c611994861d46a3fce"
+  integrity sha512-rMQkjcOFbm+ufe3bTZLyOfsOUOxyvLXZJCTARhJr+8UMSoZmqTe1K1BgkFcrW37rAchWg57yI69ORxiWvUINuQ==
+  dependencies:
+    "@babel/helper-annotate-as-pure" "^7.16.7"
+    "@babel/helper-create-class-features-plugin" "^7.16.7"
+    "@babel/helper-plugin-utils" "^7.16.7"
     "@babel/plugin-syntax-private-property-in-object" "^7.14.5"
 
 "@babel/plugin-proposal-unicode-property-regex@^7.10.4", "@babel/plugin-proposal-unicode-property-regex@^7.4.4":
@@ -1298,6 +1659,14 @@
   dependencies:
     "@babel/helper-create-regexp-features-plugin" "^7.14.5"
     "@babel/helper-plugin-utils" "^7.14.5"
+
+"@babel/plugin-proposal-unicode-property-regex@^7.16.7":
+  version "7.16.7"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-unicode-property-regex/-/plugin-proposal-unicode-property-regex-7.16.7.tgz#635d18eb10c6214210ffc5ff4932552de08188a2"
+  integrity sha512-QRK0YI/40VLhNVGIjRNAAQkEHws0cswSdFFjpFyt943YmJIU1da9uW63Iu6NFV6CxTZW5eTDCrwZUstBWgp/Rg==
+  dependencies:
+    "@babel/helper-create-regexp-features-plugin" "^7.16.7"
+    "@babel/helper-plugin-utils" "^7.16.7"
 
 "@babel/plugin-syntax-async-generators@^7.8.0", "@babel/plugin-syntax-async-generators@^7.8.4":
   version "7.8.4"
@@ -1551,6 +1920,13 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.14.5"
 
+"@babel/plugin-transform-arrow-functions@^7.16.7":
+  version "7.16.7"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-arrow-functions/-/plugin-transform-arrow-functions-7.16.7.tgz#44125e653d94b98db76369de9c396dc14bef4154"
+  integrity sha512-9ffkFFMbvzTvv+7dTp/66xvZAWASuPD5Tl9LK3Z9vhOmANo6j94rik+5YMBt4CwHVMWLWpMsriIc2zsa3WW3xQ==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.16.7"
+
 "@babel/plugin-transform-async-to-generator@^7.0.0":
   version "7.10.4"
   resolved "https://registry.yarnpkg.com/@babel/plugin-transform-async-to-generator/-/plugin-transform-async-to-generator-7.10.4.tgz#41a5017e49eb6f3cda9392a51eef29405b245a37"
@@ -1587,6 +1963,15 @@
     "@babel/helper-plugin-utils" "^7.14.5"
     "@babel/helper-remap-async-to-generator" "^7.14.5"
 
+"@babel/plugin-transform-async-to-generator@^7.16.8":
+  version "7.16.8"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-async-to-generator/-/plugin-transform-async-to-generator-7.16.8.tgz#b83dff4b970cf41f1b819f8b49cc0cfbaa53a808"
+  integrity sha512-MtmUmTJQHCnyJVrScNzNlofQJ3dLFuobYn3mwOTKHnSCMtbNsqvF71GQmJfFjdrXSsAA7iysFmYWw4bXZ20hOg==
+  dependencies:
+    "@babel/helper-module-imports" "^7.16.7"
+    "@babel/helper-plugin-utils" "^7.16.7"
+    "@babel/helper-remap-async-to-generator" "^7.16.8"
+
 "@babel/plugin-transform-block-scoped-functions@^7.0.0":
   version "7.10.4"
   resolved "https://registry.yarnpkg.com/@babel/plugin-transform-block-scoped-functions/-/plugin-transform-block-scoped-functions-7.10.4.tgz#1afa595744f75e43a91af73b0d998ecfe4ebc2e8"
@@ -1615,6 +2000,13 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.14.5"
 
+"@babel/plugin-transform-block-scoped-functions@^7.16.7":
+  version "7.16.7"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-block-scoped-functions/-/plugin-transform-block-scoped-functions-7.16.7.tgz#4d0d57d9632ef6062cdf354bb717102ee042a620"
+  integrity sha512-JUuzlzmF40Z9cXyytcbZEZKckgrQzChbQJw/5PuEHYeqzCsvebDx0K0jWnIIVcmmDOAVctCgnYs0pMcrYj2zJg==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.16.7"
+
 "@babel/plugin-transform-block-scoping@^7.0.0":
   version "7.11.1"
   resolved "https://registry.yarnpkg.com/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.11.1.tgz#5b7efe98852bef8d652c0b28144cd93a9e4b5215"
@@ -1642,6 +2034,13 @@
   integrity sha512-Pxwe0iqWJX4fOOM2kEZeUuAxHMWb9nK+9oh5d11bsLoB0xMg+mkDpt0eYuDZB7ETrY9bbcVlKUGTOGWy7BHsMQ==
   dependencies:
     "@babel/helper-plugin-utils" "^7.12.13"
+
+"@babel/plugin-transform-block-scoping@^7.16.7":
+  version "7.16.7"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.16.7.tgz#f50664ab99ddeaee5bc681b8f3a6ea9d72ab4f87"
+  integrity sha512-ObZev2nxVAYA4bhyusELdo9hb3H+A56bxH3FZMbEImZFiEDYVHXQSJ1hQKFlDnlt8G9bBrCZ5ZpURZUrV4G5qQ==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.16.7"
 
 "@babel/plugin-transform-classes@^7.0.0":
   version "7.10.4"
@@ -1697,6 +2096,20 @@
     "@babel/helper-split-export-declaration" "^7.14.5"
     globals "^11.1.0"
 
+"@babel/plugin-transform-classes@^7.16.7":
+  version "7.16.7"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-classes/-/plugin-transform-classes-7.16.7.tgz#8f4b9562850cd973de3b498f1218796eb181ce00"
+  integrity sha512-WY7og38SFAGYRe64BrjKf8OrE6ulEHtr5jEYaZMwox9KebgqPi67Zqz8K53EKk1fFEJgm96r32rkKZ3qA2nCWQ==
+  dependencies:
+    "@babel/helper-annotate-as-pure" "^7.16.7"
+    "@babel/helper-environment-visitor" "^7.16.7"
+    "@babel/helper-function-name" "^7.16.7"
+    "@babel/helper-optimise-call-expression" "^7.16.7"
+    "@babel/helper-plugin-utils" "^7.16.7"
+    "@babel/helper-replace-supers" "^7.16.7"
+    "@babel/helper-split-export-declaration" "^7.16.7"
+    globals "^11.1.0"
+
 "@babel/plugin-transform-computed-properties@^7.0.0":
   version "7.10.4"
   resolved "https://registry.yarnpkg.com/@babel/plugin-transform-computed-properties/-/plugin-transform-computed-properties-7.10.4.tgz#9ded83a816e82ded28d52d4b4ecbdd810cdfc0eb"
@@ -1724,6 +2137,13 @@
   integrity sha512-pWM+E4283UxaVzLb8UBXv4EIxMovU4zxT1OPnpHJcmnvyY9QbPPTKZfEj31EUvG3/EQRbYAGaYEUZ4yWOBC2xg==
   dependencies:
     "@babel/helper-plugin-utils" "^7.14.5"
+
+"@babel/plugin-transform-computed-properties@^7.16.7":
+  version "7.16.7"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-computed-properties/-/plugin-transform-computed-properties-7.16.7.tgz#66dee12e46f61d2aae7a73710f591eb3df616470"
+  integrity sha512-gN72G9bcmenVILj//sv1zLNaPyYcOzUho2lIJBMh/iakJ9ygCo/hEF9cpGb61SCMEDxbbyBoVQxrt+bWKu5KGw==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.16.7"
 
 "@babel/plugin-transform-destructuring@^7.0.0":
   version "7.10.4"
@@ -1753,6 +2173,13 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.14.5"
 
+"@babel/plugin-transform-destructuring@^7.16.7":
+  version "7.17.7"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.17.7.tgz#49dc2675a7afa9a5e4c6bdee636061136c3408d1"
+  integrity sha512-XVh0r5yq9sLR4vZ6eVZe8FKfIcSgaTBxVBRSYokRj2qksf6QerYnTxz9/GTuKTH/n/HwLP7t6gtlybHetJ/6hQ==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.16.7"
+
 "@babel/plugin-transform-dotall-regex@^7.10.4", "@babel/plugin-transform-dotall-regex@^7.4.4":
   version "7.12.1"
   resolved "https://registry.yarnpkg.com/@babel/plugin-transform-dotall-regex/-/plugin-transform-dotall-regex-7.12.1.tgz#a1d16c14862817b6409c0a678d6f9373ca9cd975"
@@ -1777,6 +2204,14 @@
     "@babel/helper-create-regexp-features-plugin" "^7.14.5"
     "@babel/helper-plugin-utils" "^7.14.5"
 
+"@babel/plugin-transform-dotall-regex@^7.16.7":
+  version "7.16.7"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-dotall-regex/-/plugin-transform-dotall-regex-7.16.7.tgz#6b2d67686fab15fb6a7fd4bd895d5982cfc81241"
+  integrity sha512-Lyttaao2SjZF6Pf4vk1dVKv8YypMpomAbygW+mU5cYP3S5cWTfCJjG8xV6CFdzGFlfWK81IjL9viiTvpb6G7gQ==
+  dependencies:
+    "@babel/helper-create-regexp-features-plugin" "^7.16.7"
+    "@babel/helper-plugin-utils" "^7.16.7"
+
 "@babel/plugin-transform-duplicate-keys@^7.10.4":
   version "7.12.1"
   resolved "https://registry.yarnpkg.com/@babel/plugin-transform-duplicate-keys/-/plugin-transform-duplicate-keys-7.12.1.tgz#745661baba295ac06e686822797a69fbaa2ca228"
@@ -1797,6 +2232,13 @@
   integrity sha512-iJjbI53huKbPDAsJ8EmVmvCKeeq21bAze4fu9GBQtSLqfvzj2oRuHVx4ZkDwEhg1htQ+5OBZh/Ab0XDf5iBZ7A==
   dependencies:
     "@babel/helper-plugin-utils" "^7.14.5"
+
+"@babel/plugin-transform-duplicate-keys@^7.16.7":
+  version "7.16.7"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-duplicate-keys/-/plugin-transform-duplicate-keys-7.16.7.tgz#2207e9ca8f82a0d36a5a67b6536e7ef8b08823c9"
+  integrity sha512-03DvpbRfvWIXyK0/6QiR1KMTWeT6OcQ7tbhjrXyFS02kjuX/mu5Bvnh5SDSWHxyawit2g5aWhKwI86EE7GUnTw==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.16.7"
 
 "@babel/plugin-transform-exponentiation-operator@^7.0.0":
   version "7.10.4"
@@ -1829,6 +2271,14 @@
   dependencies:
     "@babel/helper-builder-binary-assignment-operator-visitor" "^7.14.5"
     "@babel/helper-plugin-utils" "^7.14.5"
+
+"@babel/plugin-transform-exponentiation-operator@^7.16.7":
+  version "7.16.7"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-exponentiation-operator/-/plugin-transform-exponentiation-operator-7.16.7.tgz#efa9862ef97e9e9e5f653f6ddc7b665e8536fe9b"
+  integrity sha512-8UYLSlyLgRixQvlYH3J2ekXFHDFLQutdy7FfFAMm3CPZ6q9wHCwnUyiXpQCe3gVVnQlHc5nsuiEVziteRNTXEA==
+  dependencies:
+    "@babel/helper-builder-binary-assignment-operator-visitor" "^7.16.7"
+    "@babel/helper-plugin-utils" "^7.16.7"
 
 "@babel/plugin-transform-flow-strip-types@^7.0.0":
   version "7.10.4"
@@ -1874,6 +2324,13 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.14.5"
 
+"@babel/plugin-transform-for-of@^7.16.7":
+  version "7.16.7"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-for-of/-/plugin-transform-for-of-7.16.7.tgz#649d639d4617dff502a9a158c479b3b556728d8c"
+  integrity sha512-/QZm9W92Ptpw7sjI9Nx1mbcsWz33+l8kuMIQnDwgQBG5s3fAfQvkRjQ7NqXhtNcKOnPkdICmUHyCaWW06HCsqg==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.16.7"
+
 "@babel/plugin-transform-function-name@^7.0.0":
   version "7.10.4"
   resolved "https://registry.yarnpkg.com/@babel/plugin-transform-function-name/-/plugin-transform-function-name-7.10.4.tgz#6a467880e0fc9638514ba369111811ddbe2644b7"
@@ -1906,6 +2363,15 @@
     "@babel/helper-function-name" "^7.14.5"
     "@babel/helper-plugin-utils" "^7.14.5"
 
+"@babel/plugin-transform-function-name@^7.16.7":
+  version "7.16.7"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-function-name/-/plugin-transform-function-name-7.16.7.tgz#5ab34375c64d61d083d7d2f05c38d90b97ec65cf"
+  integrity sha512-SU/C68YVwTRxqWj5kgsbKINakGag0KTgq9f2iZEXdStoAbOzLHEBRYzImmA6yFo8YZhJVflvXmIHUO7GWHmxxA==
+  dependencies:
+    "@babel/helper-compilation-targets" "^7.16.7"
+    "@babel/helper-function-name" "^7.16.7"
+    "@babel/helper-plugin-utils" "^7.16.7"
+
 "@babel/plugin-transform-literals@^7.0.0":
   version "7.10.4"
   resolved "https://registry.yarnpkg.com/@babel/plugin-transform-literals/-/plugin-transform-literals-7.10.4.tgz#9f42ba0841100a135f22712d0e391c462f571f3c"
@@ -1933,6 +2399,13 @@
   integrity sha512-ql33+epql2F49bi8aHXxvLURHkxJbSmMKl9J5yHqg4PLtdE6Uc48CH1GS6TQvZ86eoB/ApZXwm7jlA+B3kra7A==
   dependencies:
     "@babel/helper-plugin-utils" "^7.14.5"
+
+"@babel/plugin-transform-literals@^7.16.7":
+  version "7.16.7"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-literals/-/plugin-transform-literals-7.16.7.tgz#254c9618c5ff749e87cb0c0cef1a0a050c0bdab1"
+  integrity sha512-6tH8RTpTWI0s2sV6uq3e/C9wPo4PTqqZps4uF0kzQ9/xPLFQtipynvmT1g/dOfEJ+0EQsHhkQ/zyRId8J2b8zQ==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.16.7"
 
 "@babel/plugin-transform-member-expression-literals@^7.0.0":
   version "7.10.4"
@@ -1962,6 +2435,13 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.14.5"
 
+"@babel/plugin-transform-member-expression-literals@^7.16.7":
+  version "7.16.7"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-member-expression-literals/-/plugin-transform-member-expression-literals-7.16.7.tgz#6e5dcf906ef8a098e630149d14c867dd28f92384"
+  integrity sha512-mBruRMbktKQwbxaJof32LT9KLy2f3gH+27a5XSuXo6h7R3vqltl0PgZ80C8ZMKw98Bf8bqt6BEVi3svOh2PzMw==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.16.7"
+
 "@babel/plugin-transform-modules-amd@^7.10.4":
   version "7.12.1"
   resolved "https://registry.yarnpkg.com/@babel/plugin-transform-modules-amd/-/plugin-transform-modules-amd-7.12.1.tgz#3154300b026185666eebb0c0ed7f8415fefcf6f9"
@@ -1987,6 +2467,15 @@
   dependencies:
     "@babel/helper-module-transforms" "^7.14.5"
     "@babel/helper-plugin-utils" "^7.14.5"
+    babel-plugin-dynamic-import-node "^2.3.3"
+
+"@babel/plugin-transform-modules-amd@^7.16.7":
+  version "7.16.7"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-modules-amd/-/plugin-transform-modules-amd-7.16.7.tgz#b28d323016a7daaae8609781d1f8c9da42b13186"
+  integrity sha512-KaaEtgBL7FKYwjJ/teH63oAmE3lP34N3kshz8mm4VMAw7U3PxjVwwUmxEFksbgsNUaO3wId9R2AVQYSEGRa2+g==
+  dependencies:
+    "@babel/helper-module-transforms" "^7.16.7"
+    "@babel/helper-plugin-utils" "^7.16.7"
     babel-plugin-dynamic-import-node "^2.3.3"
 
 "@babel/plugin-transform-modules-commonjs@^7.0.0":
@@ -2029,6 +2518,16 @@
     "@babel/helper-simple-access" "^7.14.5"
     babel-plugin-dynamic-import-node "^2.3.3"
 
+"@babel/plugin-transform-modules-commonjs@^7.16.8":
+  version "7.17.9"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.17.9.tgz#274be1a2087beec0254d4abd4d86e52442e1e5b6"
+  integrity sha512-2TBFd/r2I6VlYn0YRTz2JdazS+FoUuQ2rIFHoAxtyP/0G3D82SBLaRq9rnUkpqlLg03Byfl/+M32mpxjO6KaPw==
+  dependencies:
+    "@babel/helper-module-transforms" "^7.17.7"
+    "@babel/helper-plugin-utils" "^7.16.7"
+    "@babel/helper-simple-access" "^7.17.7"
+    babel-plugin-dynamic-import-node "^2.3.3"
+
 "@babel/plugin-transform-modules-systemjs@^7.10.4":
   version "7.12.1"
   resolved "https://registry.yarnpkg.com/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.12.1.tgz#663fea620d593c93f214a464cd399bf6dc683086"
@@ -2062,6 +2561,17 @@
     "@babel/helper-validator-identifier" "^7.14.5"
     babel-plugin-dynamic-import-node "^2.3.3"
 
+"@babel/plugin-transform-modules-systemjs@^7.16.7":
+  version "7.17.8"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.17.8.tgz#81fd834024fae14ea78fbe34168b042f38703859"
+  integrity sha512-39reIkMTUVagzgA5x88zDYXPCMT6lcaRKs1+S9K6NKBPErbgO/w/kP8GlNQTC87b412ZTlmNgr3k2JrWgHH+Bw==
+  dependencies:
+    "@babel/helper-hoist-variables" "^7.16.7"
+    "@babel/helper-module-transforms" "^7.17.7"
+    "@babel/helper-plugin-utils" "^7.16.7"
+    "@babel/helper-validator-identifier" "^7.16.7"
+    babel-plugin-dynamic-import-node "^2.3.3"
+
 "@babel/plugin-transform-modules-umd@^7.10.4":
   version "7.12.1"
   resolved "https://registry.yarnpkg.com/@babel/plugin-transform-modules-umd/-/plugin-transform-modules-umd-7.12.1.tgz#eb5a218d6b1c68f3d6217b8fa2cc82fec6547902"
@@ -2086,6 +2596,14 @@
     "@babel/helper-module-transforms" "^7.14.5"
     "@babel/helper-plugin-utils" "^7.14.5"
 
+"@babel/plugin-transform-modules-umd@^7.16.7":
+  version "7.16.7"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-modules-umd/-/plugin-transform-modules-umd-7.16.7.tgz#23dad479fa585283dbd22215bff12719171e7618"
+  integrity sha512-EMh7uolsC8O4xhudF2F6wedbSHm1HHZ0C6aJ7K67zcDNidMzVcxWdGr+htW9n21klm+bOn+Rx4CBsAntZd3rEQ==
+  dependencies:
+    "@babel/helper-module-transforms" "^7.16.7"
+    "@babel/helper-plugin-utils" "^7.16.7"
+
 "@babel/plugin-transform-named-capturing-groups-regex@^7.10.4":
   version "7.12.1"
   resolved "https://registry.yarnpkg.com/@babel/plugin-transform-named-capturing-groups-regex/-/plugin-transform-named-capturing-groups-regex-7.12.1.tgz#b407f5c96be0d9f5f88467497fa82b30ac3e8753"
@@ -2107,6 +2625,13 @@
   dependencies:
     "@babel/helper-create-regexp-features-plugin" "^7.14.5"
 
+"@babel/plugin-transform-named-capturing-groups-regex@^7.16.8":
+  version "7.16.8"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-named-capturing-groups-regex/-/plugin-transform-named-capturing-groups-regex-7.16.8.tgz#7f860e0e40d844a02c9dcf9d84965e7dfd666252"
+  integrity sha512-j3Jw+n5PvpmhRR+mrgIh04puSANCk/T/UA3m3P1MjJkhlK906+ApHhDIqBQDdOgL/r1UYpz4GNclTXxyZrYGSw==
+  dependencies:
+    "@babel/helper-create-regexp-features-plugin" "^7.16.7"
+
 "@babel/plugin-transform-new-target@^7.10.4":
   version "7.12.1"
   resolved "https://registry.yarnpkg.com/@babel/plugin-transform-new-target/-/plugin-transform-new-target-7.12.1.tgz#80073f02ee1bb2d365c3416490e085c95759dec0"
@@ -2127,6 +2652,13 @@
   integrity sha512-Nx054zovz6IIRWEB49RDRuXGI4Gy0GMgqG0cII9L3MxqgXz/+rgII+RU58qpo4g7tNEx1jG7rRVH4ihZoP4esQ==
   dependencies:
     "@babel/helper-plugin-utils" "^7.14.5"
+
+"@babel/plugin-transform-new-target@^7.16.7":
+  version "7.16.7"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-new-target/-/plugin-transform-new-target-7.16.7.tgz#9967d89a5c243818e0800fdad89db22c5f514244"
+  integrity sha512-xiLDzWNMfKoGOpc6t3U+etCE2yRnn3SM09BXqWPIZOBpL2gvVrBWUKnsJx0K/ADi5F5YC5f8APFfWrz25TdlGg==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.16.7"
 
 "@babel/plugin-transform-object-assign@^7.0.0":
   version "7.10.4"
@@ -2167,6 +2699,14 @@
     "@babel/helper-plugin-utils" "^7.14.5"
     "@babel/helper-replace-supers" "^7.14.5"
 
+"@babel/plugin-transform-object-super@^7.16.7":
+  version "7.16.7"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-object-super/-/plugin-transform-object-super-7.16.7.tgz#ac359cf8d32cf4354d27a46867999490b6c32a94"
+  integrity sha512-14J1feiQVWaGvRxj2WjyMuXS2jsBkgB3MdSN5HuC2G5nRspa5RK9COcs82Pwy5BuGcjb+fYaUj94mYcOj7rCvw==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.16.7"
+    "@babel/helper-replace-supers" "^7.16.7"
+
 "@babel/plugin-transform-parameters@^7.0.0":
   version "7.10.5"
   resolved "https://registry.yarnpkg.com/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.10.5.tgz#59d339d58d0b1950435f4043e74e2510005e2c4a"
@@ -2196,6 +2736,13 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.14.5"
 
+"@babel/plugin-transform-parameters@^7.16.7":
+  version "7.16.7"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.16.7.tgz#a1721f55b99b736511cb7e0152f61f17688f331f"
+  integrity sha512-AT3MufQ7zZEhU2hwOA11axBnExW0Lszu4RL/tAlUJBuNoRak+wehQW8h6KcXOcgjY42fHtDxswuMhMjFEuv/aw==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.16.7"
+
 "@babel/plugin-transform-property-literals@^7.0.0":
   version "7.10.4"
   resolved "https://registry.yarnpkg.com/@babel/plugin-transform-property-literals/-/plugin-transform-property-literals-7.10.4.tgz#f6fe54b6590352298785b83edd815d214c42e3c0"
@@ -2223,6 +2770,13 @@
   integrity sha512-r1uilDthkgXW8Z1vJz2dKYLV1tuw2xsbrp3MrZmD99Wh9vsfKoob+JTgri5VUb/JqyKRXotlOtwgu4stIYCmnw==
   dependencies:
     "@babel/helper-plugin-utils" "^7.14.5"
+
+"@babel/plugin-transform-property-literals@^7.16.7":
+  version "7.16.7"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-property-literals/-/plugin-transform-property-literals-7.16.7.tgz#2dadac85155436f22c696c4827730e0fe1057a55"
+  integrity sha512-z4FGr9NMGdoIl1RqavCqGG+ZuYjfZ/hkCIeuH6Do7tXmSm0ls11nYVSJqFEUOSJbDab5wC6lRE/w6YjVcr6Hqw==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.16.7"
 
 "@babel/plugin-transform-react-display-name@^7.0.0":
   version "7.10.4"
@@ -2318,6 +2872,13 @@
   dependencies:
     regenerator-transform "^0.14.2"
 
+"@babel/plugin-transform-regenerator@^7.16.7":
+  version "7.17.9"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.17.9.tgz#0a33c3a61cf47f45ed3232903683a0afd2d3460c"
+  integrity sha512-Lc2TfbxR1HOyn/c6b4Y/b6NHoTb67n/IoWLxTu4kC7h4KQnWlhCq2S8Tx0t2SVvv5Uu87Hs+6JEJ5kt2tYGylQ==
+  dependencies:
+    regenerator-transform "^0.15.0"
+
 "@babel/plugin-transform-reserved-words@^7.10.4":
   version "7.12.1"
   resolved "https://registry.yarnpkg.com/@babel/plugin-transform-reserved-words/-/plugin-transform-reserved-words-7.12.1.tgz#6fdfc8cc7edcc42b36a7c12188c6787c873adcd8"
@@ -2338,6 +2899,13 @@
   integrity sha512-cv4F2rv1nD4qdexOGsRQXJrOcyb5CrgjUH9PKrrtyhSDBNWGxd0UIitjyJiWagS+EbUGjG++22mGH1Pub8D6Vg==
   dependencies:
     "@babel/helper-plugin-utils" "^7.14.5"
+
+"@babel/plugin-transform-reserved-words@^7.16.7":
+  version "7.16.7"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-reserved-words/-/plugin-transform-reserved-words-7.16.7.tgz#1d798e078f7c5958eec952059c460b220a63f586"
+  integrity sha512-KQzzDnZ9hWQBjwi5lpY5v9shmm6IVG0U9pB18zvMu2i4H90xpT4gmqwPYsn8rObiadYe2M0gmgsiOIF5A/2rtg==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.16.7"
 
 "@babel/plugin-transform-runtime@^7.0.0":
   version "7.11.5"
@@ -2377,6 +2945,13 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.14.5"
 
+"@babel/plugin-transform-shorthand-properties@^7.16.7":
+  version "7.16.7"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-shorthand-properties/-/plugin-transform-shorthand-properties-7.16.7.tgz#e8549ae4afcf8382f711794c0c7b6b934c5fbd2a"
+  integrity sha512-hah2+FEnoRoATdIb05IOXf+4GzXYTq75TVhIn1PewihbpyrNWUt2JbudKQOETWw6QpLe+AIUpJ5MVLYTQbeeUg==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.16.7"
+
 "@babel/plugin-transform-spread@^7.0.0":
   version "7.11.0"
   resolved "https://registry.yarnpkg.com/@babel/plugin-transform-spread/-/plugin-transform-spread-7.11.0.tgz#fa84d300f5e4f57752fe41a6d1b3c554f13f17cc"
@@ -2409,6 +2984,14 @@
     "@babel/helper-plugin-utils" "^7.14.5"
     "@babel/helper-skip-transparent-expression-wrappers" "^7.14.5"
 
+"@babel/plugin-transform-spread@^7.16.7":
+  version "7.16.7"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-spread/-/plugin-transform-spread-7.16.7.tgz#a303e2122f9f12e0105daeedd0f30fb197d8ff44"
+  integrity sha512-+pjJpgAngb53L0iaA5gU/1MLXJIfXcYepLgXB3esVRf4fqmj8f2cxM3/FKaHsZms08hFQJkFccEWuIpm429TXg==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.16.7"
+    "@babel/helper-skip-transparent-expression-wrappers" "^7.16.0"
+
 "@babel/plugin-transform-sticky-regex@^7.0.0":
   version "7.10.4"
   resolved "https://registry.yarnpkg.com/@babel/plugin-transform-sticky-regex/-/plugin-transform-sticky-regex-7.10.4.tgz#8f3889ee8657581130a29d9cc91d7c73b7c4a28d"
@@ -2439,6 +3022,13 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.14.5"
 
+"@babel/plugin-transform-sticky-regex@^7.16.7":
+  version "7.16.7"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-sticky-regex/-/plugin-transform-sticky-regex-7.16.7.tgz#c84741d4f4a38072b9a1e2e3fd56d359552e8660"
+  integrity sha512-NJa0Bd/87QV5NZZzTuZG5BPJjLYadeSZ9fO6oOUoL4iQx+9EEuw/eEM92SrsT19Yc2jgB1u1hsjqDtH02c3Drw==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.16.7"
+
 "@babel/plugin-transform-template-literals@^7.0.0":
   version "7.10.5"
   resolved "https://registry.yarnpkg.com/@babel/plugin-transform-template-literals/-/plugin-transform-template-literals-7.10.5.tgz#78bc5d626a6642db3312d9d0f001f5e7639fde8c"
@@ -2468,6 +3058,13 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.14.5"
 
+"@babel/plugin-transform-template-literals@^7.16.7":
+  version "7.16.7"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-template-literals/-/plugin-transform-template-literals-7.16.7.tgz#f3d1c45d28967c8e80f53666fc9c3e50618217ab"
+  integrity sha512-VwbkDDUeenlIjmfNeDX/V0aWrQH2QiVyJtwymVQSzItFDTpxfyJh3EVaQiS0rIN/CqbLGr0VcGmuwyTdZtdIsA==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.16.7"
+
 "@babel/plugin-transform-typeof-symbol@^7.10.4":
   version "7.12.1"
   resolved "https://registry.yarnpkg.com/@babel/plugin-transform-typeof-symbol/-/plugin-transform-typeof-symbol-7.12.1.tgz#9ca6be343d42512fbc2e68236a82ae64bc7af78a"
@@ -2488,6 +3085,13 @@
   integrity sha512-lXzLD30ffCWseTbMQzrvDWqljvZlHkXU+CnseMhkMNqU1sASnCsz3tSzAaH3vCUXb9PHeUb90ZT1BdFTm1xxJw==
   dependencies:
     "@babel/helper-plugin-utils" "^7.14.5"
+
+"@babel/plugin-transform-typeof-symbol@^7.16.7":
+  version "7.16.7"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-typeof-symbol/-/plugin-transform-typeof-symbol-7.16.7.tgz#9cdbe622582c21368bd482b660ba87d5545d4f7e"
+  integrity sha512-p2rOixCKRJzpg9JB4gjnG4gjWkWa89ZoYUnl9snJ1cWIcTH/hvxZqfO+WjG6T8DRBpctEol5jw1O5rA8gkCokQ==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.16.7"
 
 "@babel/plugin-transform-typescript@^7.12.17":
   version "7.13.0"
@@ -2537,6 +3141,13 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.14.5"
 
+"@babel/plugin-transform-unicode-escapes@^7.16.7":
+  version "7.16.7"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-unicode-escapes/-/plugin-transform-unicode-escapes-7.16.7.tgz#da8717de7b3287a2c6d659750c964f302b31ece3"
+  integrity sha512-TAV5IGahIz3yZ9/Hfv35TV2xEm+kaBDaZQCn2S/hG9/CZ0DktxJv9eKfPc7yYCvOYR4JGx1h8C+jcSOvgaaI/Q==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.16.7"
+
 "@babel/plugin-transform-unicode-regex@^7.0.0":
   version "7.10.4"
   resolved "https://registry.yarnpkg.com/@babel/plugin-transform-unicode-regex/-/plugin-transform-unicode-regex-7.10.4.tgz#e56d71f9282fac6db09c82742055576d5e6d80a8"
@@ -2568,6 +3179,14 @@
   dependencies:
     "@babel/helper-create-regexp-features-plugin" "^7.14.5"
     "@babel/helper-plugin-utils" "^7.14.5"
+
+"@babel/plugin-transform-unicode-regex@^7.16.7":
+  version "7.16.7"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-unicode-regex/-/plugin-transform-unicode-regex-7.16.7.tgz#0f7aa4a501198976e25e82702574c34cfebe9ef2"
+  integrity sha512-oC5tYYKw56HO75KZVLQ+R/Nl3Hro9kf8iG0hXoaHP7tjAyCpvqBiSNe6vGrZni1Z6MggmUOC6A7VP7AVmw225Q==
+  dependencies:
+    "@babel/helper-create-regexp-features-plugin" "^7.16.7"
+    "@babel/helper-plugin-utils" "^7.16.7"
 
 "@babel/preset-env@^7.12.11":
   version "7.14.8"
@@ -2725,6 +3344,86 @@
     babel-plugin-polyfill-corejs3 "^0.2.2"
     babel-plugin-polyfill-regenerator "^0.2.2"
     core-js-compat "^3.15.0"
+    semver "^6.3.0"
+
+"@babel/preset-env@^7.16.11":
+  version "7.16.11"
+  resolved "https://registry.yarnpkg.com/@babel/preset-env/-/preset-env-7.16.11.tgz#5dd88fd885fae36f88fd7c8342475c9f0abe2982"
+  integrity sha512-qcmWG8R7ZW6WBRPZK//y+E3Cli151B20W1Rv7ln27vuPaXU/8TKms6jFdiJtF7UDTxcrb7mZd88tAeK9LjdT8g==
+  dependencies:
+    "@babel/compat-data" "^7.16.8"
+    "@babel/helper-compilation-targets" "^7.16.7"
+    "@babel/helper-plugin-utils" "^7.16.7"
+    "@babel/helper-validator-option" "^7.16.7"
+    "@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression" "^7.16.7"
+    "@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining" "^7.16.7"
+    "@babel/plugin-proposal-async-generator-functions" "^7.16.8"
+    "@babel/plugin-proposal-class-properties" "^7.16.7"
+    "@babel/plugin-proposal-class-static-block" "^7.16.7"
+    "@babel/plugin-proposal-dynamic-import" "^7.16.7"
+    "@babel/plugin-proposal-export-namespace-from" "^7.16.7"
+    "@babel/plugin-proposal-json-strings" "^7.16.7"
+    "@babel/plugin-proposal-logical-assignment-operators" "^7.16.7"
+    "@babel/plugin-proposal-nullish-coalescing-operator" "^7.16.7"
+    "@babel/plugin-proposal-numeric-separator" "^7.16.7"
+    "@babel/plugin-proposal-object-rest-spread" "^7.16.7"
+    "@babel/plugin-proposal-optional-catch-binding" "^7.16.7"
+    "@babel/plugin-proposal-optional-chaining" "^7.16.7"
+    "@babel/plugin-proposal-private-methods" "^7.16.11"
+    "@babel/plugin-proposal-private-property-in-object" "^7.16.7"
+    "@babel/plugin-proposal-unicode-property-regex" "^7.16.7"
+    "@babel/plugin-syntax-async-generators" "^7.8.4"
+    "@babel/plugin-syntax-class-properties" "^7.12.13"
+    "@babel/plugin-syntax-class-static-block" "^7.14.5"
+    "@babel/plugin-syntax-dynamic-import" "^7.8.3"
+    "@babel/plugin-syntax-export-namespace-from" "^7.8.3"
+    "@babel/plugin-syntax-json-strings" "^7.8.3"
+    "@babel/plugin-syntax-logical-assignment-operators" "^7.10.4"
+    "@babel/plugin-syntax-nullish-coalescing-operator" "^7.8.3"
+    "@babel/plugin-syntax-numeric-separator" "^7.10.4"
+    "@babel/plugin-syntax-object-rest-spread" "^7.8.3"
+    "@babel/plugin-syntax-optional-catch-binding" "^7.8.3"
+    "@babel/plugin-syntax-optional-chaining" "^7.8.3"
+    "@babel/plugin-syntax-private-property-in-object" "^7.14.5"
+    "@babel/plugin-syntax-top-level-await" "^7.14.5"
+    "@babel/plugin-transform-arrow-functions" "^7.16.7"
+    "@babel/plugin-transform-async-to-generator" "^7.16.8"
+    "@babel/plugin-transform-block-scoped-functions" "^7.16.7"
+    "@babel/plugin-transform-block-scoping" "^7.16.7"
+    "@babel/plugin-transform-classes" "^7.16.7"
+    "@babel/plugin-transform-computed-properties" "^7.16.7"
+    "@babel/plugin-transform-destructuring" "^7.16.7"
+    "@babel/plugin-transform-dotall-regex" "^7.16.7"
+    "@babel/plugin-transform-duplicate-keys" "^7.16.7"
+    "@babel/plugin-transform-exponentiation-operator" "^7.16.7"
+    "@babel/plugin-transform-for-of" "^7.16.7"
+    "@babel/plugin-transform-function-name" "^7.16.7"
+    "@babel/plugin-transform-literals" "^7.16.7"
+    "@babel/plugin-transform-member-expression-literals" "^7.16.7"
+    "@babel/plugin-transform-modules-amd" "^7.16.7"
+    "@babel/plugin-transform-modules-commonjs" "^7.16.8"
+    "@babel/plugin-transform-modules-systemjs" "^7.16.7"
+    "@babel/plugin-transform-modules-umd" "^7.16.7"
+    "@babel/plugin-transform-named-capturing-groups-regex" "^7.16.8"
+    "@babel/plugin-transform-new-target" "^7.16.7"
+    "@babel/plugin-transform-object-super" "^7.16.7"
+    "@babel/plugin-transform-parameters" "^7.16.7"
+    "@babel/plugin-transform-property-literals" "^7.16.7"
+    "@babel/plugin-transform-regenerator" "^7.16.7"
+    "@babel/plugin-transform-reserved-words" "^7.16.7"
+    "@babel/plugin-transform-shorthand-properties" "^7.16.7"
+    "@babel/plugin-transform-spread" "^7.16.7"
+    "@babel/plugin-transform-sticky-regex" "^7.16.7"
+    "@babel/plugin-transform-template-literals" "^7.16.7"
+    "@babel/plugin-transform-typeof-symbol" "^7.16.7"
+    "@babel/plugin-transform-unicode-escapes" "^7.16.7"
+    "@babel/plugin-transform-unicode-regex" "^7.16.7"
+    "@babel/preset-modules" "^0.1.5"
+    "@babel/types" "^7.16.8"
+    babel-plugin-polyfill-corejs2 "^0.3.0"
+    babel-plugin-polyfill-corejs3 "^0.5.0"
+    babel-plugin-polyfill-regenerator "^0.3.0"
+    core-js-compat "^3.20.2"
     semver "^6.3.0"
 
 "@babel/preset-env@^7.6.3":
@@ -2892,6 +3591,17 @@
     "@babel/types" "^7.4.4"
     esutils "^2.0.2"
 
+"@babel/preset-modules@^0.1.5":
+  version "0.1.5"
+  resolved "https://registry.yarnpkg.com/@babel/preset-modules/-/preset-modules-0.1.5.tgz#ef939d6e7f268827e1841638dc6ff95515e115d9"
+  integrity sha512-A57th6YRG7oR3cq/yt/Y84MvGgE0eJG2F1JLhKuyG+jFxEgrd/HAMJatiFtmOiZurz+0DkrvbheCLaV5f2JfjA==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.0.0"
+    "@babel/plugin-proposal-unicode-property-regex" "^7.4.4"
+    "@babel/plugin-transform-dotall-regex" "^7.4.4"
+    "@babel/types" "^7.4.4"
+    esutils "^2.0.2"
+
 "@babel/preset-react@^7.12.10", "@babel/preset-react@^7.14.5":
   version "7.14.5"
   resolved "https://registry.yarnpkg.com/@babel/preset-react/-/preset-react-7.14.5.tgz#0fbb769513f899c2c56f3a882fa79673c2d4ab3c"
@@ -3015,6 +3725,15 @@
     "@babel/parser" "^7.12.7"
     "@babel/types" "^7.12.7"
 
+"@babel/template@^7.16.7":
+  version "7.16.7"
+  resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.16.7.tgz#8d126c8701fde4d66b264b3eba3d96f07666d155"
+  integrity sha512-I8j/x8kHUrbYRTUxXrrMbfCa7jxkE7tZre39x3kjr9hvI82cK1FfqLygotcWN5kdPGWcLdWMHpSBavse5tWw3w==
+  dependencies:
+    "@babel/code-frame" "^7.16.7"
+    "@babel/parser" "^7.16.7"
+    "@babel/types" "^7.16.7"
+
 "@babel/traverse@^7.0.0", "@babel/traverse@^7.1.0":
   version "7.11.5"
   resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.11.5.tgz#be777b93b518eb6d76ee2e1ea1d143daa11e61c3"
@@ -3105,6 +3824,22 @@
     globals "^11.1.0"
     lodash "^4.17.19"
 
+"@babel/traverse@^7.16.7", "@babel/traverse@^7.16.8", "@babel/traverse@^7.17.3":
+  version "7.17.9"
+  resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.17.9.tgz#1f9b207435d9ae4a8ed6998b2b82300d83c37a0d"
+  integrity sha512-PQO8sDIJ8SIwipTPiR71kJQCKQYB5NGImbOviK8K+kg5xkNSYXLBupuX9QhatFowrsvo9Hj8WgArg3W7ijNAQw==
+  dependencies:
+    "@babel/code-frame" "^7.16.7"
+    "@babel/generator" "^7.17.9"
+    "@babel/helper-environment-visitor" "^7.16.7"
+    "@babel/helper-function-name" "^7.17.9"
+    "@babel/helper-hoist-variables" "^7.16.7"
+    "@babel/helper-split-export-declaration" "^7.16.7"
+    "@babel/parser" "^7.17.9"
+    "@babel/types" "^7.17.0"
+    debug "^4.1.0"
+    globals "^11.1.0"
+
 "@babel/types@^7.0.0", "@babel/types@^7.10.4", "@babel/types@^7.11.0", "@babel/types@^7.11.5", "@babel/types@^7.12.1", "@babel/types@^7.12.5", "@babel/types@^7.14.5", "@babel/types@^7.3.0", "@babel/types@^7.3.3":
   version "7.14.5"
   resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.14.5.tgz#3bb997ba829a2104cedb20689c4a5b8121d383ff"
@@ -3146,6 +3881,14 @@
   dependencies:
     "@babel/helper-validator-identifier" "^7.10.4"
     lodash "^4.17.19"
+    to-fast-properties "^2.0.0"
+
+"@babel/types@^7.16.0", "@babel/types@^7.16.7", "@babel/types@^7.16.8", "@babel/types@^7.17.0":
+  version "7.17.0"
+  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.17.0.tgz#a826e368bccb6b3d84acd76acad5c0d87342390b"
+  integrity sha512-TmKSNO4D5rzhL5bjWFcVHHLETzfQ/AmbKpKPOSjlP0WoHZ6L911fgoOKY4Alp/emzG4cHJdyN49zpgkbXFEHHw==
+  dependencies:
+    "@babel/helper-validator-identifier" "^7.16.7"
     to-fast-properties "^2.0.0"
 
 "@base2/pretty-print-object@1.0.0":
@@ -7790,6 +8533,13 @@
   dependencies:
     "@types/unist" "*"
 
+"@types/mdast@^3.0.10":
+  version "3.0.10"
+  resolved "https://registry.yarnpkg.com/@types/mdast/-/mdast-3.0.10.tgz#4724244a82a4598884cbbe9bcfd73dff927ee8af"
+  integrity sha512-W864tg/Osz1+9f4lrGTZpCSO5/z4608eUp19tbozkq2HJK6i3z1kT0H9tlADXuYIb1YYOBByU4Jsqkk75q48qA==
+  dependencies:
+    "@types/unist" "*"
+
 "@types/mdast@^3.0.3":
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/@types/mdast/-/mdast-3.0.3.tgz#2d7d671b1cd1ea3deb306ea75036c2a0407d2deb"
@@ -9752,6 +10502,15 @@ babel-plugin-polyfill-corejs2@^0.2.2:
     "@babel/helper-define-polyfill-provider" "^0.2.2"
     semver "^6.1.1"
 
+babel-plugin-polyfill-corejs2@^0.3.0:
+  version "0.3.1"
+  resolved "https://registry.yarnpkg.com/babel-plugin-polyfill-corejs2/-/babel-plugin-polyfill-corejs2-0.3.1.tgz#440f1b70ccfaabc6b676d196239b138f8a2cfba5"
+  integrity sha512-v7/T6EQcNfVLfcN2X8Lulb7DjprieyLWJK/zOWH5DUYcAgex9sP3h25Q+DLsX9TloXe3y1O8l2q2Jv9q8UVB9w==
+  dependencies:
+    "@babel/compat-data" "^7.13.11"
+    "@babel/helper-define-polyfill-provider" "^0.3.1"
+    semver "^6.1.1"
+
 babel-plugin-polyfill-corejs3@^0.1.0:
   version "0.1.7"
   resolved "https://registry.yarnpkg.com/babel-plugin-polyfill-corejs3/-/babel-plugin-polyfill-corejs3-0.1.7.tgz#80449d9d6f2274912e05d9e182b54816904befd0"
@@ -9768,12 +10527,27 @@ babel-plugin-polyfill-corejs3@^0.2.2:
     "@babel/helper-define-polyfill-provider" "^0.2.2"
     core-js-compat "^3.14.0"
 
+babel-plugin-polyfill-corejs3@^0.5.0:
+  version "0.5.2"
+  resolved "https://registry.yarnpkg.com/babel-plugin-polyfill-corejs3/-/babel-plugin-polyfill-corejs3-0.5.2.tgz#aabe4b2fa04a6e038b688c5e55d44e78cd3a5f72"
+  integrity sha512-G3uJih0XWiID451fpeFaYGVuxHEjzKTHtc9uGFEjR6hHrvNzeS/PX+LLLcetJcytsB5m4j+K3o/EpXJNb/5IEQ==
+  dependencies:
+    "@babel/helper-define-polyfill-provider" "^0.3.1"
+    core-js-compat "^3.21.0"
+
 babel-plugin-polyfill-regenerator@^0.2.2:
   version "0.2.2"
   resolved "https://registry.yarnpkg.com/babel-plugin-polyfill-regenerator/-/babel-plugin-polyfill-regenerator-0.2.2.tgz#b310c8d642acada348c1fa3b3e6ce0e851bee077"
   integrity sha512-Goy5ghsc21HgPDFtzRkSirpZVW35meGoTmTOb2bxqdl60ghub4xOidgNTHaZfQ2FaxQsKmwvXtOAkcIS4SMBWg==
   dependencies:
     "@babel/helper-define-polyfill-provider" "^0.2.2"
+
+babel-plugin-polyfill-regenerator@^0.3.0:
+  version "0.3.1"
+  resolved "https://registry.yarnpkg.com/babel-plugin-polyfill-regenerator/-/babel-plugin-polyfill-regenerator-0.3.1.tgz#2c0678ea47c75c8cc2fbb1852278d8fb68233990"
+  integrity sha512-Y2B06tvgHYt1x0yz17jGkGeeMr5FeKUu+ASJ+N6nB5lQ8Dapfg42i0OVrf8PNGJ3zKL4A23snMi1IRwrqqND7A==
+  dependencies:
+    "@babel/helper-define-polyfill-provider" "^0.3.1"
 
 babel-plugin-react-docgen@^4.2.1:
   version "4.2.1"
@@ -10694,6 +11468,17 @@ browserslist@^4.16.6:
     escalade "^3.1.1"
     node-releases "^1.1.71"
 
+browserslist@^4.17.5, browserslist@^4.20.2:
+  version "4.20.3"
+  resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-4.20.3.tgz#eb7572f49ec430e054f56d52ff0ebe9be915f8bf"
+  integrity sha512-NBhymBQl1zM0Y5dQT/O+xiLP9/rzOIQdKM/eMJBAq7yBgaB6krIYLGejrwVYnSHZdqjscB1SPuAjHwxjvN6Wdg==
+  dependencies:
+    caniuse-lite "^1.0.30001332"
+    electron-to-chromium "^1.4.118"
+    escalade "^3.1.1"
+    node-releases "^2.0.3"
+    picocolors "^1.0.0"
+
 bs-logger@0.x:
   version "0.2.6"
   resolved "https://registry.yarnpkg.com/bs-logger/-/bs-logger-0.2.6.tgz#eb7d365307a72cf974cc6cda76b68354ad336bd8"
@@ -11085,6 +11870,11 @@ caniuse-lite@^1.0.30001219:
   version "1.0.30001245"
   resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001245.tgz#45b941bbd833cb0fa53861ff2bae746b3c6ca5d4"
   integrity sha512-768fM9j1PKXpOCKws6eTo3RHmvTUsG9UrpT4WoREFeZgJBTi4/X9g565azS/rVUGtqb8nt7FjLeF5u4kukERnA==
+
+caniuse-lite@^1.0.30001332:
+  version "1.0.30001332"
+  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001332.tgz#39476d3aa8d83ea76359c70302eafdd4a1d727dd"
+  integrity sha512-10T30NYOEQtN6C11YGg411yebhvpnC6Z102+B95eAsN0oB6KUs01ivE8u+G6FMIRtIrVlYXhL+LUwQ3/hXwDWw==
 
 capture-exit@^2.0.0:
   version "2.0.0"
@@ -12047,6 +12837,14 @@ core-js-compat@^3.14.0, core-js-compat@^3.15.0, core-js-compat@^3.8.1:
   integrity sha512-Wp+BJVvwopjI+A1EFqm2dwUmWYXrvucmtIB2LgXn/Rb+gWPKYxtmb4GKHGKG/KGF1eK9jfjzT38DITbTOCX/SQ==
   dependencies:
     browserslist "^4.16.6"
+    semver "7.0.0"
+
+core-js-compat@^3.20.2, core-js-compat@^3.21.0:
+  version "3.22.2"
+  resolved "https://registry.yarnpkg.com/core-js-compat/-/core-js-compat-3.22.2.tgz#eec621eb276518efcf718d0a6d9d042c3d0cad48"
+  integrity sha512-Fns9lU06ZJ07pdfmPMu7OnkIKGPKDzXKIiuGlSvHHapwqMUF2QnnsWwtueFZtSyZEilP0o6iUeHQwpn7LxtLUw==
+  dependencies:
+    browserslist "^4.20.2"
     semver "7.0.0"
 
 core-js-compat@^3.6.2:
@@ -13323,6 +14121,11 @@ electron-to-chromium@^1.3.723:
   version "1.3.776"
   resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.776.tgz#33f6e2423b61f1bdaa8d2a103aae78a09764a75f"
   integrity sha512-V0w7eFSBoFPpdw4xexjVPZ770UDZIevSwkkj4W97XbE3IsCsTRFpa7/yXGZ88EOQAUEA09JMMsWK0xsw0kRAYw==
+
+electron-to-chromium@^1.4.118:
+  version "1.4.118"
+  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.4.118.tgz#2d917c71712dac9652cc01af46c7d0bd51552974"
+  integrity sha512-maZIKjnYDvF7Fs35nvVcyr44UcKNwybr93Oba2n3HkKDFAtk0svERkLN/HyczJDS3Fo4wU9th9fUQd09ZLtj1w==
 
 element-resize-detector@^1.2.2:
   version "1.2.3"
@@ -21743,6 +22546,11 @@ node-releases@^1.1.71:
   resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-1.1.73.tgz#dd4e81ddd5277ff846b80b52bb40c49edf7a7b20"
   integrity sha512-uW7fodD6pyW2FZNZnp/Z3hvWKeEW1Y8R1+1CnErE8cXFXzl5blBOoVB41CvMer6P6Q0S5FXDwcHgFd1Wj0U9zg==
 
+node-releases@^2.0.3:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-2.0.3.tgz#225ee7488e4a5e636da8da52854844f9d716ca96"
+  integrity sha512-maHFz6OLqYxz+VQyCAtA3PTX4UP/53pa05fyDNc9CwjvJ0yEh6+xBwKsgCxMNhS8taUKBFYxfuiaD9U/55iFaw==
+
 node-stream-zip@^1.9.1:
   version "1.11.3"
   resolved "https://registry.yarnpkg.com/node-stream-zip/-/node-stream-zip-1.11.3.tgz#223892620b4889bce9782b256a76682631c507be"
@@ -22813,6 +23621,11 @@ phin@^2.9.1:
   version "2.9.3"
   resolved "https://registry.yarnpkg.com/phin/-/phin-2.9.3.tgz#f9b6ac10a035636fb65dfc576aaaa17b8743125c"
   integrity sha512-CzFr90qM24ju5f88quFC/6qohjC144rehe5n6DH900lgXmUe86+xCKc10ev56gRKC4/BkHUoG4uSiQgBiIXwDA==
+
+picocolors@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/picocolors/-/picocolors-1.0.0.tgz#cb5bdc74ff3f51892236eaf79d68bc44564ab81c"
+  integrity sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==
 
 picomatch@^2.0.4, picomatch@^2.0.5, picomatch@^2.2.1, picomatch@^2.2.3:
   version "2.3.0"
@@ -24676,6 +25489,13 @@ refractor@^3.1.0:
     parse-entities "^2.0.0"
     prismjs "~1.22.0"
 
+regenerate-unicode-properties@^10.0.1:
+  version "10.0.1"
+  resolved "https://registry.yarnpkg.com/regenerate-unicode-properties/-/regenerate-unicode-properties-10.0.1.tgz#7f442732aa7934a3740c779bb9b3340dccc1fb56"
+  integrity sha512-vn5DU6yg6h8hP/2OkQo3K7uVILvY4iu0oI4t3HFa81UPkhGJwkRwM10JEc3upjdhHjs/k8GJY1sRBhk5sr69Bw==
+  dependencies:
+    regenerate "^1.4.2"
+
 regenerate-unicode-properties@^8.2.0:
   version "8.2.0"
   resolved "https://registry.yarnpkg.com/regenerate-unicode-properties/-/regenerate-unicode-properties-8.2.0.tgz#e5de7111d655e7ba60c057dbe9ff37c87e65cdec"
@@ -24683,7 +25503,7 @@ regenerate-unicode-properties@^8.2.0:
   dependencies:
     regenerate "^1.4.0"
 
-regenerate@^1.4.0:
+regenerate@^1.4.0, regenerate@^1.4.2:
   version "1.4.2"
   resolved "https://registry.yarnpkg.com/regenerate/-/regenerate-1.4.2.tgz#b9346d8827e8f5a32f7ba29637d398b69014848a"
   integrity sha512-zrceR/XhGYU/d/opr2EKO7aRHUeiBI8qjtfHqADTwZd6Szfy16la6kqD0MIUs5z5hx6AaKa+PixpPrR289+I0A==
@@ -24711,6 +25531,13 @@ regenerator-transform@^0.14.2:
   version "0.14.5"
   resolved "https://registry.yarnpkg.com/regenerator-transform/-/regenerator-transform-0.14.5.tgz#c98da154683671c9c4dcb16ece736517e1b7feb4"
   integrity sha512-eOf6vka5IO151Jfsw2NO9WpGX58W6wWmefK3I1zEGr0lOD0u8rwPaNqQL1aRxUaxLeKO3ArNh3VYg1KbaD+FFw==
+  dependencies:
+    "@babel/runtime" "^7.8.4"
+
+regenerator-transform@^0.15.0:
+  version "0.15.0"
+  resolved "https://registry.yarnpkg.com/regenerator-transform/-/regenerator-transform-0.15.0.tgz#cbd9ead5d77fae1a48d957cf889ad0586adb6537"
+  integrity sha512-LsrGtPmbYg19bcPHwdtmXwbW+TqNvtY4riE3P83foeHRroMbH6/2ddFBfab3t7kbzc7v7p4wbkIecHImqt0QNg==
   dependencies:
     "@babel/runtime" "^7.8.4"
 
@@ -24747,6 +25574,18 @@ regexpu-core@^4.7.1:
     unicode-match-property-ecmascript "^1.0.4"
     unicode-match-property-value-ecmascript "^1.2.0"
 
+regexpu-core@^5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/regexpu-core/-/regexpu-core-5.0.1.tgz#c531122a7840de743dcf9c83e923b5560323ced3"
+  integrity sha512-CriEZlrKK9VJw/xQGJpQM5rY88BtuL8DM+AEwvcThHilbxiTAy8vq4iJnd2tqq8wLmjbGZzP7ZcKFjbGkmEFrw==
+  dependencies:
+    regenerate "^1.4.2"
+    regenerate-unicode-properties "^10.0.1"
+    regjsgen "^0.6.0"
+    regjsparser "^0.8.2"
+    unicode-match-property-ecmascript "^2.0.0"
+    unicode-match-property-value-ecmascript "^2.0.0"
+
 registry-auth-token@3.3.2:
   version "3.3.2"
   resolved "https://registry.yarnpkg.com/registry-auth-token/-/registry-auth-token-3.3.2.tgz#851fd49038eecb586911115af845260eec983f20"
@@ -24781,10 +25620,22 @@ regjsgen@^0.5.1:
   resolved "https://registry.yarnpkg.com/regjsgen/-/regjsgen-0.5.2.tgz#92ff295fb1deecbf6ecdab2543d207e91aa33733"
   integrity sha512-OFFT3MfrH90xIW8OOSyUrk6QHD5E9JOTeGodiJeBS3J6IwlgzJMNE/1bZklWz5oTg+9dCMyEetclvCVXOPoN3A==
 
+regjsgen@^0.6.0:
+  version "0.6.0"
+  resolved "https://registry.yarnpkg.com/regjsgen/-/regjsgen-0.6.0.tgz#83414c5354afd7d6627b16af5f10f41c4e71808d"
+  integrity sha512-ozE883Uigtqj3bx7OhL1KNbCzGyW2NQZPl6Hs09WTvCuZD5sTI4JY58bkbQWa/Y9hxIsvJ3M8Nbf7j54IqeZbA==
+
 regjsparser@^0.6.4:
   version "0.6.4"
   resolved "https://registry.yarnpkg.com/regjsparser/-/regjsparser-0.6.4.tgz#a769f8684308401a66e9b529d2436ff4d0666272"
   integrity sha512-64O87/dPDgfk8/RQqC4gkZoGyyWFIEUTTh80CU6CWuK5vkCGyekIx+oKcEIYtP/RAxSQltCZHCNu/mdd7fqlJw==
+  dependencies:
+    jsesc "~0.5.0"
+
+regjsparser@^0.8.2:
+  version "0.8.4"
+  resolved "https://registry.yarnpkg.com/regjsparser/-/regjsparser-0.8.4.tgz#8a14285ffcc5de78c5b95d62bbf413b6bc132d5f"
+  integrity sha512-J3LABycON/VNEu3abOviqGHuB/LOtOQj8SKmfP9anY5GfAVw/SPjwzSjxGjbZXIxbGfqTHtJw58C2Li/WkStmA==
   dependencies:
     jsesc "~0.5.0"
 
@@ -24884,6 +25735,15 @@ remark-parse@^10.0.0:
     mdast-util-from-markdown "^1.0.0"
     unified "^10.0.0"
 
+remark-parse@^10.0.1:
+  version "10.0.1"
+  resolved "https://registry.yarnpkg.com/remark-parse/-/remark-parse-10.0.1.tgz#6f60ae53edbf0cf38ea223fe643db64d112e0775"
+  integrity sha512-1fUyHr2jLsVOkhbvPRBJ5zTKZZyD6yZzYaWCS6BPBdQ8vEMBCH+9zNCDA6tET/zHCi/jLqjCWtlJZUPk+DbnFw==
+  dependencies:
+    "@types/mdast" "^3.0.0"
+    mdast-util-from-markdown "^1.0.0"
+    unified "^10.0.0"
+
 remark-slug@^6.0.0:
   version "6.0.0"
   resolved "https://registry.yarnpkg.com/remark-slug/-/remark-slug-6.0.0.tgz#2b54a14a7b50407a5e462ac2f376022cce263e2c"
@@ -24904,6 +25764,15 @@ remark-stringify@^10.0.0:
   version "10.0.0"
   resolved "https://registry.yarnpkg.com/remark-stringify/-/remark-stringify-10.0.0.tgz#7f23659d92b2d5da489e3c858656d7bbe045f161"
   integrity sha512-3LAQqJ/qiUxkWc7fUcVuB7RtIT38rvmxfmJG8z1TiE/D8zi3JGQ2tTcTJu9Tptdpb7gFwU0whRi5q1FbFOb9yA==
+  dependencies:
+    "@types/mdast" "^3.0.0"
+    mdast-util-to-markdown "^1.0.0"
+    unified "^10.0.0"
+
+remark-stringify@^10.0.2:
+  version "10.0.2"
+  resolved "https://registry.yarnpkg.com/remark-stringify/-/remark-stringify-10.0.2.tgz#50414a6983f5008eb9e72eed05f980582d1f69d7"
+  integrity sha512-6wV3pvbPvHkbNnWB0wdDvVFHOe1hBRAx1Q/5g/EpH4RppAII6J8Gnwe7VbHuXaoKIF6LAg6ExTel/+kNqSQ7lw==
   dependencies:
     "@types/mdast" "^3.0.0"
     mdast-util-to-markdown "^1.0.0"
@@ -27702,6 +28571,11 @@ unicode-canonical-property-names-ecmascript@^1.0.4:
   resolved "https://registry.yarnpkg.com/unicode-canonical-property-names-ecmascript/-/unicode-canonical-property-names-ecmascript-1.0.4.tgz#2619800c4c825800efdd8343af7dd9933cbe2818"
   integrity sha512-jDrNnXWHd4oHiTZnx/ZG7gtUTVp+gCcTTKr8L0HjlwphROEW3+Him+IpvC+xcJEFegapiMZyZe02CyuOnRmbnQ==
 
+unicode-canonical-property-names-ecmascript@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/unicode-canonical-property-names-ecmascript/-/unicode-canonical-property-names-ecmascript-2.0.0.tgz#301acdc525631670d39f6146e0e77ff6bbdebddc"
+  integrity sha512-yY5PpDlfVIU5+y/BSCxAJRBIS1Zc2dDG3Ujq+sR0U+JjUevW2JhocOF+soROYDSaAezOzOKuyyixhD6mBknSmQ==
+
 unicode-match-property-ecmascript@^1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/unicode-match-property-ecmascript/-/unicode-match-property-ecmascript-1.0.4.tgz#8ed2a32569961bce9227d09cd3ffbb8fed5f020c"
@@ -27710,15 +28584,33 @@ unicode-match-property-ecmascript@^1.0.4:
     unicode-canonical-property-names-ecmascript "^1.0.4"
     unicode-property-aliases-ecmascript "^1.0.4"
 
+unicode-match-property-ecmascript@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/unicode-match-property-ecmascript/-/unicode-match-property-ecmascript-2.0.0.tgz#54fd16e0ecb167cf04cf1f756bdcc92eba7976c3"
+  integrity sha512-5kaZCrbp5mmbz5ulBkDkbY0SsPOjKqVS35VpL9ulMPfSl0J0Xsm+9Evphv9CoIZFwre7aJoa94AY6seMKGVN5Q==
+  dependencies:
+    unicode-canonical-property-names-ecmascript "^2.0.0"
+    unicode-property-aliases-ecmascript "^2.0.0"
+
 unicode-match-property-value-ecmascript@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/unicode-match-property-value-ecmascript/-/unicode-match-property-value-ecmascript-1.2.0.tgz#0d91f600eeeb3096aa962b1d6fc88876e64ea531"
   integrity sha512-wjuQHGQVofmSJv1uVISKLE5zO2rNGzM/KCYZch/QQvez7C1hUhBIuZ701fYXExuufJFMPhv2SyL8CyoIfMLbIQ==
 
+unicode-match-property-value-ecmascript@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/unicode-match-property-value-ecmascript/-/unicode-match-property-value-ecmascript-2.0.0.tgz#1a01aa57247c14c568b89775a54938788189a714"
+  integrity sha512-7Yhkc0Ye+t4PNYzOGKedDhXbYIBe1XEQYQxOPyhcXNMJ0WCABqqj6ckydd6pWRZTHV4GuCPKdBAUiMc60tsKVw==
+
 unicode-property-aliases-ecmascript@^1.0.4:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/unicode-property-aliases-ecmascript/-/unicode-property-aliases-ecmascript-1.1.0.tgz#dd57a99f6207bedff4628abefb94c50db941c8f4"
   integrity sha512-PqSoPh/pWetQ2phoj5RLiaqIk4kCNwoV3CI+LfGmWLKI3rE3kl1h59XpX2BjgDrmbxD9ARtQobPGU1SguCYuQg==
+
+unicode-property-aliases-ecmascript@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/unicode-property-aliases-ecmascript/-/unicode-property-aliases-ecmascript-2.0.0.tgz#0a36cb9a585c4f6abd51ad1deddb285c165297c8"
+  integrity sha512-5Zfuy9q/DFr4tfO7ZPeVXb1aPoeQSdeFMLpYuFebehDAhbuevLs5yxSZmIFN1tP5F9Wl4IpJrYojg85/zgyZHQ==
 
 unified-stream@^2.0.0:
   version "2.0.0"
@@ -27744,6 +28636,19 @@ unified@^10.0.0, unified@^10.1.0:
   version "10.1.0"
   resolved "https://registry.yarnpkg.com/unified/-/unified-10.1.0.tgz#4e65eb38fc2448b1c5ee573a472340f52b9346fe"
   integrity sha512-4U3ru/BRXYYhKbwXV6lU6bufLikoAavTwev89H5UxY8enDFaAT2VXmIXYNm6hb5oHPng/EXr77PVyDFcptbk5g==
+  dependencies:
+    "@types/unist" "^2.0.0"
+    bail "^2.0.0"
+    extend "^3.0.0"
+    is-buffer "^2.0.0"
+    is-plain-obj "^4.0.0"
+    trough "^2.0.0"
+    vfile "^5.0.0"
+
+unified@^10.1.2:
+  version "10.1.2"
+  resolved "https://registry.yarnpkg.com/unified/-/unified-10.1.2.tgz#b1d64e55dafe1f0b98bb6c719881103ecf6c86df"
+  integrity sha512-pUSWAi/RAnVy1Pif2kAoeWNBa3JVrx0MId2LASj8G+7AiHWoKZNTomq6LG326T68U7/e263X6fTdcXIy7XnF7Q==
   dependencies:
     "@types/unist" "^2.0.0"
     bail "^2.0.0"
@@ -27877,6 +28782,17 @@ unist-util-select@^4.0.0:
   resolved "https://registry.yarnpkg.com/unist-util-select/-/unist-util-select-4.0.0.tgz#8bd8ea171d937a56f56bf849861242a232d37466"
   integrity sha512-UJsER0ubbBy8KR+5zZpcF/9/aApWOzjNqfseMjcw1h0wAUqbxAf56mMewspAqXtGKiwBylnYB+PbD/XqwcYrWg==
   dependencies:
+    css-selector-parser "^1.0.0"
+    nth-check "^2.0.0"
+    unist-util-is "^5.0.0"
+    zwitch "^2.0.0"
+
+unist-util-select@^4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/unist-util-select/-/unist-util-select-4.0.1.tgz#d1913d7a0ab4e5d4b6dd1b33b3ea79b9f9645b0b"
+  integrity sha512-zPozyEo5vr1csbHf1TqlQrnuLVJ0tNMo63og3HrnINh2+OIDAgQpqHVr+0BMw1DIVHJV8ft/e6BZqtvD1Y5enw==
+  dependencies:
+    "@types/unist" "^2.0.0"
     css-selector-parser "^1.0.0"
     nth-check "^2.0.0"
     unist-util-is "^5.0.0"


### PR DESCRIPTION
Relates https://github.com/andymatuschak/orbit/issues/260, https://github.com/andymatuschak/orbit/issues/220

**What?**
Migrate the `note-sync` package to use the new ingester schema. 

**How has this been tested?**
I have used the bear markdown export script to generate a small set of test files to `interpret` against.